### PR TITLE
feat: add gpg to devcontainer for signed commits

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,6 +3,9 @@ WORKDIR /workspaces/pathpyG
 RUN apt-get update
 RUN apt-get -y install git
 
+# For signed commits: https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials#_sharing-gpg-keys
+RUN apt install gnupg2 -y
+
 # Install torch
 RUN pip install torch==2.1.0+cu121 --index-url https://download.pytorch.org/whl/cu121
 # pip install torch==2.1.0+cpu --index-url https://download.pytorch.org/whl/cpu # CPU only


### PR DESCRIPTION
When working with DevContainers, your standard setup with `ssh` keys does not work out of the box. 
Installing `gpg` by default into the DevContainer makes it possible to use your local keys, if configured correctly (see [here](https://code.visualstudio.com/remote/advancedcontainers/sharing-git-credentials)).