### PR TITLE
WIP: add colab link

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -8,6 +8,9 @@
     <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
         {% include ".icons/material/download.svg" %}
     </a>
+    <a href="{{ page.edit_url | replace('https://github.com/pathpy/pathpyG/edit/', 'https://colab.research.google.com/github/pathpy/pathpyG/blob/') }}" title="Open in Google Colab" class="md-content__button md-icon">
+      {% include ".icons/simple/googlecolab.svg" %}
+    </a>
 {% endif %}
 {{ super() }}
 {% endblock %}


### PR DESCRIPTION
Adds a Colab Link to all tutorials.

TODO: Add `!pip install git+https://github.com/pathpy/pathpyG.git` to all notebooks