### PR TITLE
Fix/version selector

### DIFF
--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix/version-selector
 
 jobs:
   publish:

--- a/.github/workflows/docs-dev.yml
+++ b/.github/workflows/docs-dev.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix/version-selector
 
 jobs:
   publish:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 # Project information
 site_name: pathpyG
-site_url: https://www.pathpy.net
+site_url: https://www.pathpy.net/
 site_author: pathpy developers
 site_description: >-
   An Open Source package facilitating next-generation network analytics and graph learning for time series data on graphs.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,7 +67,6 @@ extra:
   version:
     default:
       - dev
-      - stable
     provider: mike
 
 extra_css:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,13 +60,13 @@ plugins:
       allow_errors: False
       include_source: True
   - git-revision-date-localized
-  - mike # Versioning
+  - mike: # Versioning
+      alias_type: redirect
   - markdown-exec # Execute code blocks to show the output; Also for rendering of directory trees
 
 extra:
   version:
-    default:
-      - dev
+    default: dev
     provider: mike
 
 extra_css:


### PR DESCRIPTION
This changes the way that the documentation uses aliases for versioning from symbolic links to automatic redirects. This circumvents the 404 error that was happening when switching from an alias to its real name.