### PR TITLE
workaround/API change that closes issue #131

### DIFF
--- a/src/pathpyG/core/TemporalGraph.py
+++ b/src/pathpyG/core/TemporalGraph.py
@@ -127,11 +127,13 @@ class TemporalGraph(Graph):
         else:
             edge_index = torch.stack((self.data.src, self.data.dst))
 
+        n = edge_index.max().item()+1
+
         if weighted:
-            i, w = torch_geometric.utils.coalesce(edge_index, torch.ones(edge_index.size(1)))
-            return Graph(Data(edge_index=EdgeIndex(data=i), edge_weight=w), self.mapping)
+            i, w = torch_geometric.utils.coalesce(edge_index, torch.ones(edge_index.size(1)))            
+            return Graph(Data(edge_index=EdgeIndex(data=i, sparse_size=(n,n)), edge_weight=w), self.mapping)
         else:
-            return Graph.from_edge_index(EdgeIndex(data=edge_index), self.mapping)
+            return Graph.from_edge_index(EdgeIndex(data=edge_index, sparse_size=(n,n)), self.mapping)
 
     def get_window(self, start: int, end: int) -> TemporalGraph:
         """Returns an instance of the TemporalGraph that captures all time-stamped 


### PR DESCRIPTION
To fix issue #131, we now impose the correct size of the CSR matrix used in the `Graph` class. For user-generated instances of `EdgeIndex` we check the sparse size and issue an Error if they do not correspond to the number of nodes (determined based on the node indices). 

Note that this imposes a subtle change of the API, as for graphs where nodes have in- or out-degree zero the `EdgeIndex` has now to be created as follows:

```
import torch
from torch_geometric import EdgeIndex
import pathpyG as pp

e = EdgeIndex(torch.tensor([[0,0,0], [0,1,2]]), sparse_size=(3,3))
g = pp.Graph(e)
```

The correct sparse size is automatically created when initializing a graph from a torch.tensor or from an edge_list, i.e. the following works: 

```
import torch
import pathpyG as pp

e = torch.tensor([[0,0,0], [0,1,2]])
g = pp.Graph(e)
g = pp.Graph.from_edge_list([('a', 'a'), ('a', 'b'), ('a', 'c')])
```
