### PR TITLE
solving unweighted hons issue

### DIFF
--- a/src/pathpyG/core/MultiOrderModel.py
+++ b/src/pathpyG/core/MultiOrderModel.py
@@ -251,7 +251,7 @@ class MultiOrderModel:
         if dag_graph.edge_weight is None:
             edge_weight = torch.ones(edge_index.size(1), device=edge_index.device)
         else:
-            edge_weight = dag_graph.edge_attr
+            edge_weight = dag_graph.edge_weight
         if mode == "diffusion":
             edge_weight = (
                 edge_weight / degree(edge_index[0], dtype=torch.long, num_nodes=node_sequence.size(0))[edge_index[0]]

--- a/src/pathpyG/core/MultiOrderModel.py
+++ b/src/pathpyG/core/MultiOrderModel.py
@@ -248,7 +248,7 @@ class MultiOrderModel:
         dag_graph = next(iter(DataLoader(dag_data.dags, batch_size=len(dag_data.dags)))).to(config["torch"]["device"])
         edge_index = dag_graph.edge_index
         node_sequence = dag_graph.node_sequence
-        if dag_graph.edge_attr is None:
+        if dag_graph.edge_weight is None:
             edge_weight = torch.ones(edge_index.size(1), device=edge_index.device)
         else:
             edge_weight = dag_graph.edge_attr


### PR DESCRIPTION
The higher-order networks were unweighted. This snippet:
```
dag_data = pp.DAGData(pp.IndexMap(list("01234")))
dag_data.append_walk(list("023"), weight=20)
dag_data.append_walk(list("124"), weight=30)

m = pp.MultiOrderModel.from_DAGs(dag_data, max_order=2)

hon_1 = m.layers[1]
hon_2 = m.layers[2]
print(hon_1.data.edge_weight)
print(hon_2.data.edge_weight)
```
Gives this:
```
tensor([1., 1., 1., 1.])
tensor([1., 1.])
```