### PR TITLE
IndexMap improvements

### DIFF
--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -155,7 +155,10 @@ class Graph:
         """
 
         if mapping is None:
-            mapping = IndexMap(np.unique(edge_list))
+            edge_array = np.array(edge_list)
+            if np.issubdtype(edge_array.dtype, str) and np.char.isnumeric(edge_array).all():
+                edge_array = edge_array.astype(int)
+            mapping = IndexMap(np.unique(edge_array))
 
         if num_nodes is None:
             num_nodes = mapping.num_ids()

--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -156,9 +156,10 @@ class Graph:
 
         if mapping is None:
             edge_array = np.array(edge_list)
-            if np.issubdtype(edge_array.dtype, str) and np.char.isnumeric(edge_array).all():
-                edge_array = edge_array.astype(int)
-            mapping = IndexMap(np.unique(edge_array))
+            node_ids = np.unique(edge_array)
+            if np.issubdtype(node_ids.dtype, str) and np.char.isnumeric(node_ids).all():
+                node_ids = np.sort(node_ids.astype(int)).astype(str)
+            mapping = IndexMap(node_ids)
 
         if num_nodes is None:
             num_nodes = mapping.num_ids()

--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -11,6 +11,8 @@ from typing import (
     Generator,
 )
 
+import numpy as np
+
 import torch
 
 import torch_geometric
@@ -153,35 +155,15 @@ class Graph:
         """
 
         if mapping is None:
-            node_ids = set()
-            for v, w in edge_list:
-                node_ids.add(v)
-                node_ids.add(w)
-            numeric_ids = True
-            for x in node_ids:
-                if not x.isnumeric():
-                    numeric_ids = False
-            node_list = list(node_ids)
-            if numeric_ids:  # sort numerically
-                node_list.sort(key=int)
-            else:  # sort lexicograpbically
-                node_list.sort()
-            mapping = IndexMap(node_list)
-
-        sources = []
-        targets = []
-        for v, w in edge_list:
-            sources.append(mapping.to_idx(v))
-            targets.append(mapping.to_idx(w))
+            mapping = IndexMap(np.unique(edge_list))
 
         if num_nodes is None:
             num_nodes = mapping.num_ids()
 
         edge_index = EdgeIndex(
-            [sources, targets],
+            mapping.to_idxs(edge_list).T.contiguous(),
             sparse_size=(num_nodes, num_nodes),
             is_undirected=is_undirected,
-            device=config["torch"]["device"],
         )
         return Graph(Data(edge_index=edge_index, num_nodes=num_nodes), mapping=mapping)
 

--- a/src/pathpyG/core/index_map.py
+++ b/src/pathpyG/core/index_map.py
@@ -1,3 +1,5 @@
+"""IndexMap class for mapping node indices to IDs."""
+
 from __future__ import annotations
 from typing import List, Union, Any
 

--- a/src/pathpyG/core/index_map.py
+++ b/src/pathpyG/core/index_map.py
@@ -138,8 +138,6 @@ class IndexMap:
         if self.has_ids:
             if self.id_shape != (-1,):
                 node = tuple(node)
-            elif isinstance(node, str) and np.issubdtype(self.node_ids.dtype, int) and node.isnumeric():
-                node = int(node)
             return self.id_to_idx[node]
         else:
             return node
@@ -157,10 +155,7 @@ class IndexMap:
             if not isinstance(nodes, np.ndarray):
                 nodes = np.array(nodes)
 
-            if np.issubdtype(self.node_ids.dtype, int) and np.issubdtype(nodes.dtype, str) and np.char.isnumeric(nodes).all():
-                nodes = nodes.astype(int)
             shape = nodes.shape
-
             if self.id_shape == (-1,):
                 return torch.tensor([self.id_to_idx[node] for node in nodes.flatten()]).reshape(shape)
             else:

--- a/src/pathpyG/core/index_map.py
+++ b/src/pathpyG/core/index_map.py
@@ -1,21 +1,96 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING, List, Union
+from typing import List, Union, Any
 
 import torch
 import numpy as np
 
 
 class IndexMap:
-    """Maps node indices to string ids"""
+    """Maps node indices to IDs.
+
+    This class keeps a mapping from any node ID, e.g. names (strings) or higher-order IDs (tuples),
+    to an index of the corresponding node in the initial list of IDs, enabling fast lookup of node IDs
+    from a `torch_geometric.data.Data` object.
+
+    Attributes:
+        node_ids: `numpy.ndarray` storing the node IDs, enabling fast lookup of multiple node IDs from indices.
+        id_to_idx: `dict` mapping each node ID to its index.
+        id_shape: `tuple` storing the shape of the ID. The default shape is (-1,) for first-order IDs.
+            For higher-order IDs, the shape will be `(-1, k)` with order `k`.
+
+    Examples:
+        Initialize an `IndexMap` object with a list of string IDs:
+
+        >>> index_map = IndexMap(["A", "B", "C"])
+        >>> print(index_map)
+        A -> 0
+        B -> 1
+        C -> 2
+
+        Add additional IDs to the mapping:
+
+        >>> index_map.add_id("D")
+        >>> print(index_map.to_idx("D"))
+        3
+
+        Map indices to IDs. Use `to_id` for single indices and `to_ids` for multiple indices.
+        Note that the shape of the given index list will be preserved in the output:
+
+        >>> print(index_map.to_id(1))
+        B
+        >>> print(index_map.to_ids([0, 2]))
+        ['A' 'C']
+
+        Map IDs to indices. Works analogously to the reversed mapping and can, e.g., be used to
+        create an `edge_index` tensor from a list of edges given by source and destination node IDs:
+
+        >>> edge_index = index_map.to_idxs([["A", "B"], ["B", "C"], ["C", "D"]]).T
+
+        Create a higher-order ID mapping:
+
+        >>> index_map = IndexMap([("A", "B"), ("A", "C"), ("B", "C")])
+        >>> print(index_map)
+        ('A', 'B') -> 0
+        ('A', 'C') -> 1
+        ('B', 'C') -> 2
+
+        The methods above work analogously for higher-order IDs:
+
+        >>> print(index_map.to_id(1))
+        ('A', 'C')
+        >>> print(index_map.to_ids([[0], [2]]))
+        [[('A', 'B')], [('B', 'C')]]
+    """
 
     def __init__(self, node_ids: Union[List[str], None] = None) -> None:
         """Initialize mapping from indices to node IDs.
+
+        The mapping will keep the ordering of the IDs as provided by `node_ids`. If the IDs are not unique,
+        an error will be raised.
 
         Args:
             node_ids: List of node IDs to initialize mapping.
 
         Raises:
             ValueError: If IDs are not unique.
+
+        Examples:
+            Initialize an `IndexMap` object with a list of string IDs:
+
+            >>> index_map = IndexMap(["A", "C", "B"])
+            >>> print(index_map)
+            A -> 0
+            C -> 1
+            B -> 2
+
+            Handle non-unique IDs and sort IDs lexicographically:
+
+            >>> node_ids = ["A", "C", "B", "A"]
+            >>> index_map = IndexMap(np.unique(node_ids))
+            >>> print(index_map)
+            A -> 0
+            B -> 1
+            C -> 2
         """
         self.node_ids: np.ndarray | None = None
         self.id_to_idx: dict = {}
@@ -29,28 +104,65 @@ class IndexMap:
 
         Returns:
             Whether mapping has IDs.
+
+        Examples:
+            Check if mapping has IDs:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.has_ids)
+            False
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.has_ids)
+            True
         """
         return self.node_ids is not None
 
     def num_ids(self) -> int:
-        """Return number of IDs.
+        """Return number of IDs. If mapping is not defined, return 0.
 
         Returns:
             Number of IDs.
+
+        Examples:
+            Get number of IDs:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.num_ids())
+            0
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.num_ids())
+            3
+
+            >>> index_map = IndexMap([("A", "B"), ("A", "C"), ("B", "C")])
+            >>> print(index_map.num_ids())
+            3
         """
         if self.node_ids is None:
             return 0
         else:
             return len(self.node_ids)
 
-    def add_id(self, node_id: any) -> None:
-        """Assigns additional ID to next consecutive index.
+    def add_id(self, node_id: Any) -> None:
+        """Assigns additional ID to the next consecutive index.
 
         Args:
             node_id: ID to assign.
 
         Raises:
             ValueError: If ID is already present in the mapping.
+
+        Examples:
+            Add an additional ID to the mapping:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> index_map.add_id("D")
+            >>> print(index_map)
+            A -> 0
+            B -> 1
+            C -> 2
+            D -> 3
         """
         if node_id not in self.id_to_idx:
             idx = self.num_ids()
@@ -74,6 +186,18 @@ class IndexMap:
 
         Raises:
             ValueError: If IDs are not unique or already present in the mapping.
+
+        Examples:
+            Add additional IDs to the mapping:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> index_map.add_ids(["E", "D"])
+            >>> print(index_map)
+            A -> 0
+            B -> 1
+            C -> 2
+            E -> 3
+            D -> 4
         """
         cur_num_ids = self.num_ids()
         if isinstance(node_ids, list) and isinstance(node_ids[0], (list, tuple)):
@@ -101,30 +225,67 @@ class IndexMap:
 
         Returns:
             ID if mapping is defined, index otherwise.
+
+        Examples:
+            Map index to ID:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.to_id(1))
+            B
+
+            No mapping defined:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.to_id(1))
+            1
         """
         if self.has_ids:
             if self.id_shape == (-1,):
-                return self.node_ids[idx]
+                return self.node_ids[idx]  # type: ignore
             else:
-                return tuple(self.node_ids[idx])
+                return tuple(self.node_ids[idx])  # type: ignore
         else:
             return idx
 
     def to_ids(self, idxs: list | tuple | np.ndarray) -> np.ndarray:
-        """Map list of indices to IDs if mapping is defined, return indices otherwise.
+        """Map list of indices to IDs if mapping is defined, return indices otherwise. The shape of the given index
+        list will be preserved in the output.
 
         Args:
             idxs: Indices to map.
 
         Returns:
             IDs if mapping is defined, indices otherwise.
+
+        Examples:
+            Map list of indices to IDs:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.to_ids([0, 2]))
+            ['A' 'C']
+
+            No mapping defined:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.to_ids(torch.tensor([0, 2])))
+            tensor([0 2])
+
+            Map edge_index tensor to array of edges:
+
+            >>> edge_index = torch.tensor([[0, 2, 2, 3], [1, 1, 3, 0]])
+            >>> index_map = IndexMap(["A", "B", "C", "D"])
+            >>> print(index_map.to_ids(edge_index.T))
+            [['A' 'B']
+             ['C' 'B']
+             ['C' 'D']
+             ['D' 'A']]
         """
         if self.has_ids:
             if not isinstance(idxs, np.ndarray):
                 idxs = np.array(idxs)
-            return self.node_ids[idxs]
+            return self.node_ids[idxs]  # type: ignore
         else:
-            return idxs
+            return idxs  # type: ignore
 
     def to_idx(self, node: Union[str, int]) -> int:
         """Map argument (ID or index) to index if mapping is defined, return argument otherwise.
@@ -134,6 +295,19 @@ class IndexMap:
 
         Returns:
             Index if mapping is defined, argument otherwise.
+
+        Examples:
+            Map ID to index:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.to_idx("B"))
+            1
+
+            No mapping defined:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.to_idx(1))
+            1
         """
         if self.has_ids:
             if self.id_shape != (-1,):
@@ -143,13 +317,35 @@ class IndexMap:
             return node
 
     def to_idxs(self, nodes: list | tuple | np.ndarray) -> torch.Tensor:
-        """Map list of arguments (IDs or indices) to indices if mapping is defined, return argument otherwise.
+        """Map list of arguments (IDs or indices) to indices if mapping is defined, return argument otherwise. The shape
+        of the given argument list will be preserved in the output.
 
         Args:
             nodes: IDs or indices to map.
 
         Returns:
             Indices if mapping is defined, arguments otherwise.
+
+        Examples:
+            Map list of IDs to indices:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.to_idxs(["B", "A"]))
+            tensor([1, 0])
+
+            No mapping defined:
+
+            >>> index_map = IndexMap()
+            >>> print(index_map.to_idxs(torch.tensor([1, 0])))
+            tensor([1, 0])
+
+            Map list of edges to edge_index tensor:
+
+            >>> edges = [["A", "B"], ["B", "C"], ["C", "D"]]
+            >>> index_map = IndexMap(np.unique(edges))
+            >>> print(index_map.to_idxs(edges).T)
+            tensor([[0, 1, 2],
+                    [1, 2, 3]])
         """
         if self.has_ids:
             if not isinstance(nodes, np.ndarray):
@@ -166,6 +362,20 @@ class IndexMap:
             return torch.tensor(nodes)
 
     def __str__(self) -> str:
+        """Return string representation of the mapping.
+
+        Returns:
+            String representation of the mapping.
+
+        Examples:
+            Print string representation of the mapping:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map)
+            A -> 0
+            B -> 1
+            C -> 2
+        """
         s = ""
         for v in self.id_to_idx:
             s += str(v) + " -> " + str(self.to_idx(v)) + "\n"

--- a/src/pathpyG/core/index_map.py
+++ b/src/pathpyG/core/index_map.py
@@ -138,6 +138,8 @@ class IndexMap:
         if self.has_ids:
             if self.id_shape != (-1,):
                 node = tuple(node)
+            elif isinstance(node, str) and np.issubdtype(self.node_ids.dtype, int) and node.isnumeric():
+                node = int(node)
             return self.id_to_idx[node]
         else:
             return node
@@ -154,7 +156,11 @@ class IndexMap:
         if self.has_ids:
             if not isinstance(nodes, np.ndarray):
                 nodes = np.array(nodes)
+
+            if np.issubdtype(self.node_ids.dtype, int) and np.issubdtype(nodes.dtype, str) and np.char.isnumeric(nodes).all():
+                nodes = nodes.astype(int)
             shape = nodes.shape
+
             if self.id_shape == (-1,):
                 return torch.tensor([self.id_to_idx[node] for node in nodes.flatten()]).reshape(shape)
             else:

--- a/src/pathpyG/core/path_data.py
+++ b/src/pathpyG/core/path_data.py
@@ -168,7 +168,7 @@ class PathData:
 
     def map_node_seq(self, node_seq: list | tuple) -> list:
         """Map a sequence of node indices (e.g. representing a higher-order node) to node IDs"""
-        return self.mapping.to_ids(node_seq)
+        return self.mapping.to_ids(node_seq).tolist()
 
     def __str__(self) -> str:
         """Return a string representation of the PathData object."""
@@ -188,7 +188,7 @@ class PathData:
                 weights = [1.0] * len(paths)
 
         mapping = IndexMap()
-        mapping.add_ids(np.concatenate([np.array(path) for path in paths]))
+        mapping.add_ids(np.unique(np.hstack(paths)))
 
         pathdata = PathData(mapping)
         pathdata.append_walks(node_seqs=paths, weights=weights)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -70,6 +70,24 @@ def test_from_edge_list():
     assert isinstance(g.edge_to_index, dict)
     assert torch.equal(g.data.edge_index, EdgeIndex([[0,1,2], [1,2,0]]))
 
+    edge_list = [
+        ("a", "c"),
+        ("b", "c"),
+    ]
+    g = Graph.from_edge_list(edge_list)
+    assert g.mapping.to_idx('a') == 0
+    assert g.mapping.to_idx('b') == 1
+    assert g.mapping.to_idx('c') == 2
+
+    edge_list = [
+        (1, 12),
+        (2, 1),
+    ]
+    g = Graph.from_edge_list(edge_list)
+    assert g.mapping.to_idx(1) == 0
+    assert g.mapping.to_idx(2) == 1
+    assert g.mapping.to_idx(12) == 2
+
 
 def test_from_edge_list_undirected():
     edge_list = [

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -88,6 +88,18 @@ def test_from_edge_list():
     assert g.mapping.to_idx(2) == 1
     assert g.mapping.to_idx(12) == 2
 
+    edge_list = [
+        ("1", "12"),
+        ("2", "1"),
+        ("21", "3")
+    ]
+    g = Graph.from_edge_list(edge_list)
+    assert g.mapping.to_idx('1') == 0
+    assert g.mapping.to_idx('2') == 1
+    assert g.mapping.to_idx('3') == 2
+    assert g.mapping.to_idx('12') == 3
+    assert g.mapping.to_idx('21') == 4
+
 
 def test_from_edge_list_undirected():
     edge_list = [

--- a/tests/core/test_index_map.py
+++ b/tests/core/test_index_map.py
@@ -26,7 +26,7 @@ def test_index_mapping():
     assert mapping.num_ids() == 1
     assert mapping.node_ids == ["a"]
 
-    with pytest.warns(Warning):
+    with pytest.raises(ValueError):
         mapping.add_id("a")
 
     assert mapping.num_ids() == 1
@@ -47,21 +47,22 @@ def test_index_mapping_bulk():
     assert mapping.num_ids() == 5
     assert (mapping.node_ids == ["a", "b", "c", "d", "e"]).all()
     assert mapping.to_idxs(["a", "b", "c", "d", "e"]).tolist() == [0, 1, 2, 3, 4]
-    assert mapping.to_ids([0, 1, 2, 3, 4]) == ["a", "b", "c", "d", "e"]
+    assert mapping.to_ids([0, 1, 2, 3, 4]).tolist() == ["a", "b", "c", "d", "e"]
 
-    with pytest.warns(Warning):
+    with pytest.raises(ValueError):
         mapping.add_ids(("a", "a", "f", "f"))
+    mapping.add_ids(["f"])
     assert mapping.num_ids() == 6
     assert (mapping.node_ids == ["a", "b", "c", "d", "e", "f"]).all()
     assert mapping.to_idxs(["a", "b", "c", "d", "e", "f"]).tolist() == [0, 1, 2, 3, 4, 5]
-    assert mapping.to_ids([0, 1, 2, 3, 4, 5]) == ["a", "b", "c", "d", "e", "f"]
+    assert mapping.to_ids([0, 1, 2, 3, 4, 5]).tolist() == ["a", "b", "c", "d", "e", "f"]
 
-    with pytest.warns(Warning):
+    with pytest.raises(ValueError):
         mapping.add_id("a")
     assert mapping.num_ids() == 6
     assert (mapping.node_ids == ["a", "b", "c", "d", "e", "f"]).all()
     assert mapping.to_idxs(("a", "b", "c", "d", "e", "f")).tolist() == [0, 1, 2, 3, 4, 5]
-    assert mapping.to_ids(torch.tensor([0, 1, 2, 3, 4, 5])) == ["a", "b", "c", "d", "e", "f"]
+    assert mapping.to_ids(torch.tensor([0, 1, 2, 3, 4, 5])).tolist() == ["a", "b", "c", "d", "e", "f"]
     assert mapping.to_idxs(np.array(["a", "b", "c", "d", "e", "f"])).tolist() == [0, 1, 2, 3, 4, 5]
 
     mapping.add_ids(np.array(["h", "i", "g"]))
@@ -81,7 +82,7 @@ def test_integer_ids():
     assert mapping.to_id(0) == 0
     assert mapping.to_id(3) == 1
 
-    assert mapping.to_ids([0, 1, 2]) == [0, 2, 3]
+    assert mapping.to_ids([0, 1, 2]).tolist() == [0, 2, 3]
     assert (mapping.to_idxs([0, 1, 2]) == torch.tensor([0, 3, 1])).all()
 
 
@@ -93,6 +94,13 @@ def test_tuple_ids():
 
     assert mapping.to_id(0) == (1, 2)
     assert mapping.to_id(1) == (3, 4)
+
+    assert (mapping.to_ids([0, 1]) == np.array([(1, 2), (3, 4)])).all()
+    assert (mapping.to_idxs([(1, 2), (3, 4)]) == torch.tensor([0, 1])).all()
+
+    mapping = IndexMap([(1, 2, 3), (4, 5, 6)])
+    assert (mapping.to_ids([[0, 1], [0, 0]]) == np.array([[(1, 2, 3), (4, 5, 6)], [(1, 2, 3), (1, 2, 3)]])).all()
+    assert (mapping.to_idxs([[(1, 2, 3), (4, 5, 6)], [(1, 2, 3), (1, 2, 3)]]) == torch.tensor([[0, 1], [0, 0]])).all()
 
 
 def test_float_ids():
@@ -106,17 +114,18 @@ def test_float_ids():
     assert mapping.to_id(0) == 0.0
     assert mapping.to_id(3) == 1.0
 
-    assert mapping.to_ids([0, 1, 7]) == [0.0, 2.0, 9.0]
+    assert mapping.to_ids([0, 1, 7]).tolist() == [0.0, 2.0, 9.0]
     assert (mapping.to_idxs([0.0, 1.0, 2.0]) == torch.tensor([0, 3, 1])).all()
 
 
 def test_bulk_ids():
     node_ids = np.array(["a", "c", "b", "d", "a", "e"])
-    with pytest.warns(Warning):
+    with pytest.raises(ValueError):
         mapping = IndexMap(node_ids)
+    mapping = IndexMap(np.unique(node_ids))
 
     assert mapping.to_idx("a") == 0
-    assert mapping.to_idx("c") == 1
+    assert mapping.to_idx("c") == 2
 
-    assert mapping.to_ids(torch.tensor([[0, 1], [2, 3], [0, 4]])) == [["a", "c"], ["b", "d"], ["a", "e"]]
-    assert (mapping.to_idxs([["a", "c"], ["b", "d"], ["a", "e"]]) == torch.tensor([[0, 1], [2, 3], [0, 4]])).all()
+    assert mapping.to_ids(torch.tensor([[0, 2], [1, 3], [0, 4]])).tolist() == [["a", "c"], ["b", "d"], ["a", "e"]]
+    assert (mapping.to_idxs([["a", "c"], ["b", "d"], ["a", "e"]]) == torch.tensor([[0, 2], [1, 3], [0, 4]])).all()

--- a/tests/core/test_temporal_graph.py
+++ b/tests/core/test_temporal_graph.py
@@ -21,6 +21,7 @@ def test_init():
 def test_from_edge_list():
     tedges = [("a", "b", 1), ("b", "c", 5), ("c", "d", 9), ("c", "e", 9)]
     tgraph = TemporalGraph.from_edge_list(tedges)
+    print(tgraph.data.time)
     assert tgraph.N == 5
     assert tgraph.M == 4
     assert tgraph.start_time == 1

--- a/tests/core/test_temporal_graph.py
+++ b/tests/core/test_temporal_graph.py
@@ -12,7 +12,6 @@ from pathpyG.utils import to_numpy
 def test_init():
     tdata = Data(edge_index=torch.IntTensor([[1, 3, 2, 4], [2, 4, 3, 5]]), time=torch.Tensor([1000, 1100, 1010, 2000]))
     tgraph = TemporalGraph(tdata)
-    print(to_numpy(tgraph.data.edge_index))
     # After ordering the edges by time
     assert (to_numpy(tgraph.data.edge_index) == np.array([[1, 2, 3, 4], [2, 3, 4, 5]])).all()
     assert equal(tgraph.data.time, torch.tensor([1000, 1010, 1100, 2000]))
@@ -21,7 +20,6 @@ def test_init():
 def test_from_edge_list():
     tedges = [("a", "b", 1), ("b", "c", 5), ("c", "d", 9), ("c", "e", 9)]
     tgraph = TemporalGraph.from_edge_list(tedges)
-    print(tgraph.data.time)
     assert tgraph.N == 5
     assert tgraph.M == 4
     assert tgraph.start_time == 1


### PR DESCRIPTION
Includes the following:
 - [x] Solve Issue #159: `IndexMap.to_idxs(...)` and `IndexMap.to_ids(...)` can now get any shape as input. The output will have the same shape. Note that if the `IndexMap` is used for higher-order representation and, thus, a `tuple` is used as `node_id`, this still works.
- [x] Simplify some of the usages of IndexMap, e.g. in `Graph.from_edge_list(...)`. Probably also more efficient.
- [x] Might also solve #158 although I was still not able to reproduce the problem.
- [x] Improve `IndexMap` documentation and add examples.