### PR TITLE
fix temporal shortest path

### DIFF
--- a/src/pathpyG/algorithms/temporal.py
+++ b/src/pathpyG/algorithms/temporal.py
@@ -9,11 +9,9 @@ import torch
 from scipy.sparse.csgraph import dijkstra
 
 from pathpyG import Graph
+from pathpyG.utils import to_numpy
 from pathpyG.core.temporal_graph import TemporalGraph
 
-from pathpyG import config
-
-device = config['torch']['device']
 
 def lift_order_temporal(g: TemporalGraph, delta: int = 1):
 
@@ -28,58 +26,78 @@ def lift_order_temporal(g: TemporalGraph, delta: int = 1):
     # lift order: find possible continuations for edges in each time stamp
     for i in tqdm(range(unique_t.size(0))):
         t = unique_t[i]
-        
+
         # find indices of all source edges that occur at unique timestamp t
-        src_time_mask = (timestamps == t)
-        src_edges = edge_index[:,src_time_mask]
+        src_time_mask = timestamps == t
+        src_edges = edge_index[:, src_time_mask]
         src_edge_idx = indices[src_time_mask]
 
         # find indices of all edges that can possibly continue edges occurring at time t for the given delta
-        dst_time_mask = (timestamps > t) & (timestamps <= t+delta)
-        dst_edges = edge_index[:,dst_time_mask]
+        dst_time_mask = (timestamps > t) & (timestamps <= t + delta)
+        dst_edges = edge_index[:, dst_time_mask]
         dst_edge_idx = indices[dst_time_mask]
 
-        if dst_edge_idx.size(0)>0 and src_edge_idx.size(0)>0:
+        if dst_edge_idx.size(0) > 0 and src_edge_idx.size(0) > 0:
 
-            # compute second-order edges between src and dst idx for all edges where dst in src_edges matches src in dst_edges        
+            # compute second-order edges between src and dst idx for all edges where dst in src_edges matches src in dst_edges
             x = torch.cartesian_prod(src_edge_idx, dst_edge_idx).t()
             src_edges = torch.index_select(edge_index, dim=1, index=x[0])
             dst_edges = torch.index_select(edge_index, dim=1, index=x[1])
-            ho_edge_index = x[:,torch.where(src_edges[1,:] == dst_edges[0,:])[0]]
+            ho_edge_index = x[:, torch.where(src_edges[1, :] == dst_edges[0, :])[0]]
             second_order.append(ho_edge_index)
 
     ho_index = torch.cat(second_order, dim=1)
     return ho_index
 
-def temporal_shortest_paths(g: TemporalGraph, delta: int):
+
+def temporal_shortest_paths(g: TemporalGraph, delta: int) -> Tuple[np.ndarray, np.ndarray]:
+    """Compute shortest time-respecting paths in a temporal graph.
+
+    Args:
+        g: Temporal graph to compute shortest paths on.
+        delta: Maximum time difference between events in a path.
+
+    Returns:
+        Tuple of two numpy arrays:
+        - dist: Shortest time-respecting path distances between all first-order nodes.
+        - pred: Predecessor matrix for shortest time-respecting paths between all first-order nodes.
+    """
     # generate temporal event DAG
-    edge_index = lift_order_temporal(g, delta).to(device)
+    edge_index = lift_order_temporal(g, delta)
 
     # Add indices of first-order nodes as src and dst of paths in augmented
     # temporal event DAG
-    src_edges_src = (g.data.edge_index[0] + g.M).to(device)
-    src_edges_dst = (torch.arange(0, g.data.edge_index.size(1))).to(device)
+    src_edges_src = g.data.edge_index[0] + g.M
+    src_edges_dst = torch.arange(0, g.data.edge_index.size(1), device=g.data.edge_index.device)
 
-    dst_edges_src = torch.arange(0, g.data.edge_index.size(1)).to(device)
-    dst_edges_dst = (g.data.edge_index[1] + g.M + g.N).to(device)
+    dst_edges_src = torch.arange(0, g.data.edge_index.size(1), device=g.data.edge_index.device)
+    dst_edges_dst = g.data.edge_index[1] + g.M + g.N
 
     # add edges from source to edges and from edges to destinations
-    src_edges = torch.stack([src_edges_src, src_edges_dst]).to(device)
-    dst_edges = torch.stack([dst_edges_src, dst_edges_dst]).to(device)
+    src_edges = torch.stack([src_edges_src, src_edges_dst])
+    dst_edges = torch.stack([dst_edges_src, dst_edges_dst])
     edge_index = torch.cat([edge_index, src_edges, dst_edges], dim=1)
 
     # create sparse scipy matrix
-    event_graph = Graph.from_edge_index(edge_index, num_nodes=g.M + 2 * g.N) 
+    event_graph = Graph.from_edge_index(edge_index, num_nodes=g.M + 2 * g.N)
     m = event_graph.get_sparse_adj_matrix()
 
-    #print(f"Created temporal event DAG with {event_graph.N} nodes and {event_graph.M} edges")
+    # print(f"Created temporal event DAG with {event_graph.N} nodes and {event_graph.M} edges")
 
     # run disjktra for all source nodes
-    dist, pred = dijkstra(m, directed=True, indices=np.arange(g.M, g.M+g.N),  return_predecessors=True, unweighted=True)
+    dist, pred = dijkstra(
+        m, directed=True, indices=np.arange(g.M, g.M + g.N), return_predecessors=True, unweighted=True
+    )
 
     # limit to first-order destinations and correct distances
-    dist_fo = dist[:, g.M+g.N:] - 1    
-    pred_fo = pred[:, g.N+g.M:]
+    dist_fo = dist[:, g.M + g.N :] - 1
     np.fill_diagonal(dist_fo, 0)
+
+    # limit to first-order destinations and correct predecessors
+    pred_fo = pred[:, g.N + g.M :]
+    pred_fo[pred_fo == -9999] = -1
+    idx_map = np.concatenate([to_numpy(g.data.edge_index[0].cpu()), [-1]])
+    pred_fo = idx_map[pred_fo]
+    np.fill_diagonal(pred_fo, np.arange(g.N))
 
     return dist_fo, pred_fo

--- a/tests/algorithms/test_temporal.py
+++ b/tests/algorithms/test_temporal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import numpy as np
 import torch
 from torch_geometric import EdgeIndex
 
@@ -16,46 +17,77 @@ def test_lift_order_temporal(simple_temporal_graph):
     assert torch.equal(event_graph.data.edge_index, EdgeIndex([[0, 1, 1], [1, 2, 3]]))
 
 
-# def test_time_respecting_paths(long_temporal_graph):
-#     paths = time_respecting_paths(long_temporal_graph, delta=5)
-#     assert paths[1] == [['a', 'b'],
-#                         ['b', 'f'],
-#                         ['b', 'i'],
-#                         ['c', 'f'],
-#                         ['c', 'i'],
-#                         ['f', 'h']]
-#     assert paths[3] == [['a', 'b', 'c', 'd'],
-#                         ['a', 'b', 'c', 'e'],
-#                         ['c', 'f', 'a', 'g']]
-#     assert paths[2] == [['a', 'c', 'h'],
-#                         ['a', 'g', 'h']]
+def test_temporal_shortest_paths(long_temporal_graph):
+    dist, pred = temporal_shortest_paths(long_temporal_graph, delta=10)
+    assert dist.shape == (long_temporal_graph.N, long_temporal_graph.N)
+    assert pred.shape == (long_temporal_graph.N, long_temporal_graph.N)
 
+    true_dist = np.array(
+        [
+            [0.0, 1.0, 1.0, 3.0, 3.0, 3.0, 1.0, 2.0, float("inf")],
+            [3.0, 0.0, 1.0, 2.0, 2.0, 1.0, 4.0, 5.0, 1.0],
+            [2.0, float("inf"), 0.0, 1.0, 1.0, 1.0, 3.0, 1.0, 1.0],
+            [
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                0.0,
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+            ],
+            [
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                0.0,
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+            ],
+            [1.0, float("inf"), float("inf"), float("inf"), float("inf"), 0.0, 2.0, 1.0, float("inf")],
+            [
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                0.0,
+                1.0,
+                float("inf"),
+            ],
+            [float("inf"), float("inf"), float("inf"), float("inf"), float("inf"), 1.0, float("inf"), 0.0, 1.0],
+            [
+                float("inf"),
+                1.0,
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                float("inf"),
+                0.0,
+            ],
+        ]
+    )
+    assert np.allclose(dist, true_dist, equal_nan=True)
 
-# def test_temporal_shortest_paths(long_temporal_graph):
-#     sp, sp_lengths, counts = temporal_shortest_paths(long_temporal_graph, delta=5)
-#     assert torch.equal(sp[1], torch.tensor([[0, 1],
-#         [0, 2],
-#         [0, 6],
-#         [1, 2],
-#         [1, 5],
-#         [1, 8],
-#         [2, 3],
-#         [2, 4],
-#         [2, 5],
-#         [2, 7],
-#         [2, 8],
-#         [5, 0],
-#         [5, 7],
-#         [6, 7],
-#         [7, 5],
-#         [7, 8],
-#         [8, 1]]))
-#     assert torch.equal(sp[2], torch.tensor([[0, 2, 7],
-#         [0, 6, 7],
-#         [1, 2, 3],
-#         [1, 2, 4],
-#         [2, 5, 0],
-#         [5, 0, 6]]))
-#     assert torch.equal(sp[3], torch.tensor([[0, 1, 2, 3],
-#         [0, 1, 2, 4],
-#         [2, 5, 0, 6]]))
+    true_pred = np.array(
+        [
+            [0, 0, 0, 2, 2, 2, 0, 2, -1],
+            [5, 1, 1, 2, 2, 1, 0, 6, 1],
+            [5, -1, 2, 2, 2, 2, 0, 2, 2],
+            [-1, -1, -1, 3, -1, -1, -1, -1, -1],
+            [-1, -1, -1, -1, 4, -1, -1, -1, -1],
+            [5, -1, -1, -1, -1, 5, 0, 5, -1],
+            [-1, -1, -1, -1, -1, -1, 6, 6, -1],
+            [-1, -1, -1, -1, -1, 7, -1, 7, 7],
+            [-1, 8, -1, -1, -1, -1, -1, -1, 8],
+        ]
+    )
+    assert np.allclose(pred, true_pred)


### PR DESCRIPTION
Fixes a Bug where the predecessor matrix that was returned by `temporal_shortest_paths(...)` contained indices pointing to the second order nodes instead of the first order nodes. Also adds some documentation and a unit-test.