### PR TITLE
fixes issue #219

### DIFF
--- a/docs/tutorial/_scalability_analysis.ipynb
+++ b/docs/tutorial/_scalability_analysis.ipynb
@@ -1,0 +1,716 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathpyG as pp\n",
+    "import torch\n",
+    "import copy\n",
+    "import time\n",
+    "import numpy as np\n",
+    "from collections import defaultdict\n",
+    "\n",
+    "import pprint \n",
+    "printer = pprint.PrettyPrinter(indent=4)\n",
+    "pp.config['device'] = 'cpu'\n",
+    "import seaborn as sns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Data(edge_index=[2, 2172808], time=[2172808], node__pos=[96], analyses_average_degree=22633.416666666668, analyses_degree_assortativity=0.47204699336753403, analyses_degree_std_dev=21814.46446725327, analyses_diameter=3, analyses_edge_properties=[2], analyses_edge_reciprocity=1.0, analyses_global_clustering=0.8413817881426829, analyses_hashimoto_radius=58.674375265299176, analyses_is_bipartite=False, analyses_is_directed=False, analyses_knn_proj_1=3.5514214936943516, analyses_knn_proj_2=2.0132492259108, analyses_largest_component_fraction=1.0, analyses_mixing_time=19.3400781427721, analyses_num_edges=1086404, analyses_num_vertices=96, analyses_transition_gap=0.9496079163109559, analyses_vertex_properties=[1])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "g = pp.io.read_netzschleuder_graph('reality_mining', time_attr='time')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cpu\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 11%|█         | 3539/33452 [01:17<10:59, 45.38it/s]\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m g\u001b[38;5;241m.\u001b[39mdata\u001b[38;5;241m.\u001b[39mto(pp\u001b[38;5;241m.\u001b[39mconfig[\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mdevice\u001b[39m\u001b[38;5;124m'\u001b[39m])\n\u001b[1;32m      2\u001b[0m \u001b[38;5;28mprint\u001b[39m(g\u001b[38;5;241m.\u001b[39mdata\u001b[38;5;241m.\u001b[39medge_index\u001b[38;5;241m.\u001b[39mdevice)\n\u001b[0;32m----> 3\u001b[0m event_graph \u001b[38;5;241m=\u001b[39m \u001b[43mpp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43malgorithms\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mlift_order_temporal\u001b[49m\u001b[43m(\u001b[49m\u001b[43mg\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdelta\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;241;43m3600\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m      4\u001b[0m \u001b[38;5;28mprint\u001b[39m(event_graph\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m1\u001b[39m))\n",
+      "File \u001b[0;32m/workspaces/pathpyG/src/pathpyG/algorithms/temporal.py:36\u001b[0m, in \u001b[0;36mlift_order_temporal\u001b[0;34m(g, delta)\u001b[0m\n\u001b[1;32m     34\u001b[0m \u001b[38;5;66;03m# find indices of all edges that can possibly continue edges occurring at time t for the given delta\u001b[39;00m\n\u001b[1;32m     35\u001b[0m dst_time_mask \u001b[38;5;241m=\u001b[39m (timestamps \u001b[38;5;241m>\u001b[39m t) \u001b[38;5;241m&\u001b[39m (timestamps \u001b[38;5;241m<\u001b[39m\u001b[38;5;241m=\u001b[39m t \u001b[38;5;241m+\u001b[39m delta)\n\u001b[0;32m---> 36\u001b[0m dst_node_mask \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39misin(\u001b[43medge_index\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;241;43m0\u001b[39;49m\u001b[43m]\u001b[49m, edge_index[\u001b[38;5;241m1\u001b[39m, src_edge_idx])\n\u001b[1;32m     37\u001b[0m dst_edge_idx \u001b[38;5;241m=\u001b[39m indices[dst_time_mask \u001b[38;5;241m&\u001b[39m dst_node_mask]\n\u001b[1;32m     39\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m dst_edge_idx\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m0\u001b[39m) \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m0\u001b[39m \u001b[38;5;129;01mand\u001b[39;00m src_edge_idx\u001b[38;5;241m.\u001b[39msize(\u001b[38;5;241m0\u001b[39m) \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m0\u001b[39m:\n\u001b[1;32m     40\u001b[0m \n\u001b[1;32m     41\u001b[0m     \u001b[38;5;66;03m# compute second-order edges between src and dst idx for all edges where dst in src_edges matches src in dst_edges\u001b[39;00m\n",
+      "File \u001b[0;32m/opt/conda/lib/python3.10/site-packages/torch_geometric/edge_index.py:1037\u001b[0m, in \u001b[0;36mEdgeIndex.__torch_function__\u001b[0;34m(cls, func, types, args, kwargs)\u001b[0m\n\u001b[1;32m   1034\u001b[0m         edge_index\u001b[38;5;241m.\u001b[39m_indptr \u001b[38;5;241m=\u001b[39m colptr\n\u001b[1;32m   1035\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m edge_index\n\u001b[0;32m-> 1037\u001b[0m \u001b[38;5;129m@classmethod\u001b[39m\n\u001b[1;32m   1038\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m__torch_function__\u001b[39m(\n\u001b[1;32m   1039\u001b[0m     \u001b[38;5;28mcls\u001b[39m: Type,\n\u001b[1;32m   1040\u001b[0m     func: Callable,\n\u001b[1;32m   1041\u001b[0m     types: Tuple[Type, \u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m],\n\u001b[1;32m   1042\u001b[0m     args: Tuple[Any, \u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;241m.\u001b[39m] \u001b[38;5;241m=\u001b[39m (),\n\u001b[1;32m   1043\u001b[0m     kwargs: Optional[Dict[\u001b[38;5;28mstr\u001b[39m, Any]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mNone\u001b[39;00m,\n\u001b[1;32m   1044\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Any:\n\u001b[1;32m   1045\u001b[0m     \u001b[38;5;66;03m# `EdgeIndex` should be treated as a regular PyTorch tensor for all\u001b[39;00m\n\u001b[1;32m   1046\u001b[0m     \u001b[38;5;66;03m# standard PyTorch functionalities. However,\u001b[39;00m\n\u001b[1;32m   1047\u001b[0m     \u001b[38;5;66;03m# * some of its metadata can be transferred to new functions, e.g.,\u001b[39;00m\n\u001b[1;32m   1048\u001b[0m     \u001b[38;5;66;03m#   `torch.cat(dim=1)` can inherit the sparse matrix size, or\u001b[39;00m\n\u001b[1;32m   1049\u001b[0m     \u001b[38;5;66;03m#   `torch.narrow(dim=1)` can inherit cached pointers.\u001b[39;00m\n\u001b[1;32m   1050\u001b[0m     \u001b[38;5;66;03m# * not all operations lead to valid `EdgeIndex` tensors again, e.g.,\u001b[39;00m\n\u001b[1;32m   1051\u001b[0m     \u001b[38;5;66;03m#   `torch.sum()` does not yield a `EdgeIndex` as its output, or\u001b[39;00m\n\u001b[1;32m   1052\u001b[0m     \u001b[38;5;66;03m#   `torch.cat(dim=0) violates the [2, *] shape assumption.\u001b[39;00m\n\u001b[1;32m   1053\u001b[0m \n\u001b[1;32m   1054\u001b[0m     \u001b[38;5;66;03m# To account for this, we hold a number of `HANDLED_FUNCTIONS` that\u001b[39;00m\n\u001b[1;32m   1055\u001b[0m     \u001b[38;5;66;03m# implement specific functions for valid `EdgeIndex` routines.\u001b[39;00m\n\u001b[1;32m   1056\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m func \u001b[38;5;129;01min\u001b[39;00m HANDLED_FUNCTIONS:\n\u001b[1;32m   1057\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m HANDLED_FUNCTIONS[func](\u001b[38;5;241m*\u001b[39margs, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m(kwargs \u001b[38;5;129;01mor\u001b[39;00m {}))\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "g.data.to(pp.config['device'])\n",
+    "print(g.data.edge_index.device)\n",
+    "event_graph = pp.algorithms.lift_order_temporal(g, delta=3600)\n",
+    "print(event_graph.size(1))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[tensor([[0, 1],\n",
+      "        [1, 2]], device='cuda:0'), tensor([[0, 1],\n",
+      "        [1, 2]], device='cuda:0')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "x = torch.tensor([[0,1],[1,2]]).to('cuda')\n",
+    "y = torch.tensor([[0,1],[1,2]]).to('cuda')\n",
+    "l = [x,y]\n",
+    "\n",
+    "print(l)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_mo_scalability(exp):\n",
+    "    res = copy.deepcopy(exp)\n",
+    "    pp.config['device'] = exp['device']\n",
+    "    start_time = time.time()\n",
+    "    g = pp.io.read_netzschleuder_graph(exp['record'], exp['network'], time_attr=exp['time_attr'])\n",
+    "    g.data.to(exp['device'])\n",
+    "    res['read_time_ns'] = time.time() - start_time\n",
+    "    res['temp_net_nodes'] = g.N\n",
+    "    res['temp_net_edges'] = g.M\n",
+    "    res['temp_net_events'] = g.data.edge_index.size(1)\n",
+    "\n",
+    "    start_time = time.time()\n",
+    "    eg = pp.algorithms.lift_order_temporal(g, delta=exp['delta'])\n",
+    "    eg.to(exp['device'])\n",
+    "    res['lift_event_graph_time'] = time.time() - start_time\n",
+    "    res['event_graph_edges'] = eg.size(1)\n",
+    "\n",
+    "    start_time = time.time()\n",
+    "    m = pp.MultiOrderModel.from_temporal_graph(g, delta=exp['delta'], max_order=exp['max_order'])\n",
+    "    res['mo_time'] = time.time() - start_time\n",
+    "    res['max_order_nodes'] = m.layers[exp['max_order']].N\n",
+    "    res['max_order_edges'] = m.layers[exp['max_order']].M\n",
+    "    return res\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:05<00:00, 4419.76it/s]\n",
+      "100%|██████████| 24039/24039 [00:05<00:00, 4341.64it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 1.0,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 89,\n",
+      "    'lift_event_graph_time': 5.45093846321106,\n",
+      "    'max_order': 2,\n",
+      "    'max_order_edges': 34,\n",
+      "    'max_order_nodes': 1303,\n",
+      "    'mo_time': 5.6448304653167725,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.5371692180633545,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:06<00:00, 3628.34it/s]\n",
+      "100%|██████████| 24039/24039 [00:06<00:00, 3587.17it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 1.0,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 89,\n",
+      "    'lift_event_graph_time': 6.637180328369141,\n",
+      "    'max_order': 3,\n",
+      "    'max_order_edges': 4,\n",
+      "    'max_order_nodes': 34,\n",
+      "    'mo_time': 6.799363136291504,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.5883340835571289,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:10<00:00, 2393.87it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2415.46it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 900.75,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 54271,\n",
+      "    'lift_event_graph_time': 10.089986324310303,\n",
+      "    'max_order': 2,\n",
+      "    'max_order_edges': 1232,\n",
+      "    'max_order_nodes': 1303,\n",
+      "    'mo_time': 10.088692426681519,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.47829651832580566,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:10<00:00, 2318.32it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2436.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 900.75,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 54271,\n",
+      "    'lift_event_graph_time': 10.420698165893555,\n",
+      "    'max_order': 3,\n",
+      "    'max_order_edges': 1117,\n",
+      "    'max_order_nodes': 1232,\n",
+      "    'mo_time': 10.119099617004395,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.4850621223449707,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2522.59it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2557.16it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 1800.5,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 77048,\n",
+      "    'lift_event_graph_time': 9.585360288619995,\n",
+      "    'max_order': 2,\n",
+      "    'max_order_edges': 1344,\n",
+      "    'max_order_nodes': 1303,\n",
+      "    'mo_time': 9.54270601272583,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.5124361515045166,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2634.00it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2552.80it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 1800.5,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 77048,\n",
+      "    'lift_event_graph_time': 9.175652503967285,\n",
+      "    'max_order': 3,\n",
+      "    'max_order_edges': 1305,\n",
+      "    'max_order_nodes': 1344,\n",
+      "    'mo_time': 9.715734481811523,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.4568464756011963,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2564.72it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2569.76it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 2700.25,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 92451,\n",
+      "    'lift_event_graph_time': 9.429511070251465,\n",
+      "    'max_order': 2,\n",
+      "    'max_order_edges': 1408,\n",
+      "    'max_order_nodes': 1303,\n",
+      "    'mo_time': 9.486212730407715,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.4557836055755615,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2467.55it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2573.09it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 2700.25,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 92451,\n",
+      "    'lift_event_graph_time': 9.789302349090576,\n",
+      "    'max_order': 3,\n",
+      "    'max_order_edges': 1416,\n",
+      "    'max_order_nodes': 1408,\n",
+      "    'mo_time': 9.676949739456177,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.560659646987915,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2594.05it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2542.90it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 3600.0,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 105280,\n",
+      "    'lift_event_graph_time': 9.317339897155762,\n",
+      "    'max_order': 2,\n",
+      "    'max_order_edges': 1453,\n",
+      "    'max_order_nodes': 1303,\n",
+      "    'mo_time': 9.582679748535156,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.5140020847320557,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n",
+      "Mapping node attributes based on node indices in column `index`\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 24039/24039 [00:09<00:00, 2619.24it/s]\n",
+      "100%|██████████| 24039/24039 [00:09<00:00, 2508.51it/s]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{   'delta': 3600.0,\n",
+      "    'device': 'cpu',\n",
+      "    'event_graph_edges': 105280,\n",
+      "    'lift_event_graph_time': 9.226924180984497,\n",
+      "    'max_order': 3,\n",
+      "    'max_order_edges': 1506,\n",
+      "    'max_order_nodes': 1453,\n",
+      "    'mo_time': 9.954979658126831,\n",
+      "    'network': 'sms',\n",
+      "    'read_time_ns': 0.43961000442504883,\n",
+      "    'record': 'copenhagen',\n",
+      "    'temp_net_edges': 24333,\n",
+      "    'temp_net_events': 24333,\n",
+      "    'temp_net_nodes': 568,\n",
+      "    'time_attr': 'timestamp'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "results = defaultdict(lambda: defaultdict())\n",
+    "exp = {}\n",
+    "exp['device'] = 'cpu'\n",
+    "exp['record'] = 'copenhagen'\n",
+    "exp['network'] = 'sms'\n",
+    "exp['time_attr'] = 'timestamp'\n",
+    "\n",
+    "for delta in np.linspace(1, 3600, 5):\n",
+    "\n",
+    "    for k in range(2,4):\n",
+    "        exp['delta'] = delta\n",
+    "        \n",
+    "        exp['max_order'] = k\n",
+    "\n",
+    "        res = test_mo_scalability(exp)\n",
+    "        printer.pprint(res)\n",
+    "        results[delta][k] = res"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "defaultdict(<function <lambda> at 0x7f92531c1cf0>,\n",
+      "            {   1.0: defaultdict(None,\n",
+      "                                 {   2: {   'delta': 1.0,\n",
+      "                                            'device': 'cpu',\n",
+      "                                            'event_graph_edges': 89,\n",
+      "                                            'lift_event_graph_time': 5.45093846321106,\n",
+      "                                            'max_order': 2,\n",
+      "                                            'max_order_edges': 34,\n",
+      "                                            'max_order_nodes': 1303,\n",
+      "                                            'mo_time': 5.6448304653167725,\n",
+      "                                            'network': 'sms',\n",
+      "                                            'read_time_ns': 0.5371692180633545,\n",
+      "                                            'record': 'copenhagen',\n",
+      "                                            'temp_net_edges': 24333,\n",
+      "                                            'temp_net_events': 24333,\n",
+      "                                            'temp_net_nodes': 568,\n",
+      "                                            'time_attr': 'timestamp'},\n",
+      "                                     3: {   'delta': 1.0,\n",
+      "                                            'device': 'cpu',\n",
+      "                                            'event_graph_edges': 89,\n",
+      "                                            'lift_event_graph_time': 6.637180328369141,\n",
+      "                                            'max_order': 3,\n",
+      "                                            'max_order_edges': 4,\n",
+      "                                            'max_order_nodes': 34,\n",
+      "                                            'mo_time': 6.799363136291504,\n",
+      "                                            'network': 'sms',\n",
+      "                                            'read_time_ns': 0.5883340835571289,\n",
+      "                                            'record': 'copenhagen',\n",
+      "                                            'temp_net_edges': 24333,\n",
+      "                                            'temp_net_events': 24333,\n",
+      "                                            'temp_net_nodes': 568,\n",
+      "                                            'time_attr': 'timestamp'}}),\n",
+      "                900.75: defaultdict(None,\n",
+      "                                    {   2: {   'delta': 900.75,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 54271,\n",
+      "                                               'lift_event_graph_time': 10.089986324310303,\n",
+      "                                               'max_order': 2,\n",
+      "                                               'max_order_edges': 1232,\n",
+      "                                               'max_order_nodes': 1303,\n",
+      "                                               'mo_time': 10.088692426681519,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.47829651832580566,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'},\n",
+      "                                        3: {   'delta': 900.75,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 54271,\n",
+      "                                               'lift_event_graph_time': 10.420698165893555,\n",
+      "                                               'max_order': 3,\n",
+      "                                               'max_order_edges': 1117,\n",
+      "                                               'max_order_nodes': 1232,\n",
+      "                                               'mo_time': 10.119099617004395,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.4850621223449707,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'}}),\n",
+      "                1800.5: defaultdict(None,\n",
+      "                                    {   2: {   'delta': 1800.5,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 77048,\n",
+      "                                               'lift_event_graph_time': 9.585360288619995,\n",
+      "                                               'max_order': 2,\n",
+      "                                               'max_order_edges': 1344,\n",
+      "                                               'max_order_nodes': 1303,\n",
+      "                                               'mo_time': 9.54270601272583,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.5124361515045166,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'},\n",
+      "                                        3: {   'delta': 1800.5,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 77048,\n",
+      "                                               'lift_event_graph_time': 9.175652503967285,\n",
+      "                                               'max_order': 3,\n",
+      "                                               'max_order_edges': 1305,\n",
+      "                                               'max_order_nodes': 1344,\n",
+      "                                               'mo_time': 9.715734481811523,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.4568464756011963,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'}}),\n",
+      "                2700.25: defaultdict(None,\n",
+      "                                     {   2: {   'delta': 2700.25,\n",
+      "                                                'device': 'cpu',\n",
+      "                                                'event_graph_edges': 92451,\n",
+      "                                                'lift_event_graph_time': 9.429511070251465,\n",
+      "                                                'max_order': 2,\n",
+      "                                                'max_order_edges': 1408,\n",
+      "                                                'max_order_nodes': 1303,\n",
+      "                                                'mo_time': 9.486212730407715,\n",
+      "                                                'network': 'sms',\n",
+      "                                                'read_time_ns': 0.4557836055755615,\n",
+      "                                                'record': 'copenhagen',\n",
+      "                                                'temp_net_edges': 24333,\n",
+      "                                                'temp_net_events': 24333,\n",
+      "                                                'temp_net_nodes': 568,\n",
+      "                                                'time_attr': 'timestamp'},\n",
+      "                                         3: {   'delta': 2700.25,\n",
+      "                                                'device': 'cpu',\n",
+      "                                                'event_graph_edges': 92451,\n",
+      "                                                'lift_event_graph_time': 9.789302349090576,\n",
+      "                                                'max_order': 3,\n",
+      "                                                'max_order_edges': 1416,\n",
+      "                                                'max_order_nodes': 1408,\n",
+      "                                                'mo_time': 9.676949739456177,\n",
+      "                                                'network': 'sms',\n",
+      "                                                'read_time_ns': 0.560659646987915,\n",
+      "                                                'record': 'copenhagen',\n",
+      "                                                'temp_net_edges': 24333,\n",
+      "                                                'temp_net_events': 24333,\n",
+      "                                                'temp_net_nodes': 568,\n",
+      "                                                'time_attr': 'timestamp'}}),\n",
+      "                3600.0: defaultdict(None,\n",
+      "                                    {   2: {   'delta': 3600.0,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 105280,\n",
+      "                                               'lift_event_graph_time': 9.317339897155762,\n",
+      "                                               'max_order': 2,\n",
+      "                                               'max_order_edges': 1453,\n",
+      "                                               'max_order_nodes': 1303,\n",
+      "                                               'mo_time': 9.582679748535156,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.5140020847320557,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'},\n",
+      "                                        3: {   'delta': 3600.0,\n",
+      "                                               'device': 'cpu',\n",
+      "                                               'event_graph_edges': 105280,\n",
+      "                                               'lift_event_graph_time': 9.226924180984497,\n",
+      "                                               'max_order': 3,\n",
+      "                                               'max_order_edges': 1506,\n",
+      "                                               'max_order_nodes': 1453,\n",
+      "                                               'mo_time': 9.954979658126831,\n",
+      "                                               'network': 'sms',\n",
+      "                                               'read_time_ns': 0.43961000442504883,\n",
+      "                                               'record': 'copenhagen',\n",
+      "                                               'temp_net_edges': 24333,\n",
+      "                                               'temp_net_events': 24333,\n",
+      "                                               'temp_net_nodes': 568,\n",
+      "                                               'time_attr': 'timestamp'}})})\n"
+     ]
+    }
+   ],
+   "source": [
+    "printer.pprint(results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: >"
+      ]
+     },
+     "execution_count": 58,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAi4AAAGiCAYAAADA0E3hAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAAcw0lEQVR4nO3db2zdVf3A8U/b0VsItEzn2m0WKyiiAhturBYkiKk2gUz3wDjBbHPhj+AkuEZlY7CK6DoRyKIrLkwQH6ibEDDGLUOsLgapWdjWBGSDwMBNYwsT184iLWu/vweG+qvrYLf0z077eiX3wY7n3O+5Hkbf3H8tyLIsCwCABBSO9QYAAI6VcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSkXe4/OEPf4h58+bF9OnTo6CgIH75y1++5Zpt27bFRz7ykcjlcvG+970v7r///iFsFQCY6PIOl66urpg5c2Y0NTUd0/wXXnghLrvssrjkkkuitbU1vvrVr8ZVV10VjzzySN6bBQAmtoK380sWCwoK4uGHH4758+cfdc6NN94Ymzdvjqeeeqp/7POf/3wcPHgwtm7dOtRLAwAT0KSRvkBLS0vU1tYOGKurq4uvfvWrR13T3d0d3d3d/X/u6+uLV155Jd75zndGQUHBSG0VABhGWZbFoUOHYvr06VFYODxvqx3xcGlra4vy8vIBY+Xl5dHZ2Rn//ve/48QTTzxiTWNjY9x6660jvTUAYBTs378/3v3udw/LfY14uAzFihUror6+vv/PHR0dcdppp8X+/fujtLR0DHcGAByrzs7OqKysjFNOOWXY7nPEw6WioiLa29sHjLW3t0dpaemgz7ZERORyucjlckeMl5aWChcASMxwvs1jxL/HpaamJpqbmweMPfroo1FTUzPSlwYAxpm8w+Vf//pXtLa2Rmtra0T85+POra2tsW/fvoj4z8s8ixYt6p9/7bXXxt69e+Mb3/hG7NmzJ+6+++74xS9+EcuWLRueRwAATBh5h8sTTzwR5513Xpx33nkREVFfXx/nnXderFq1KiIi/v73v/dHTETEe9/73ti8eXM8+uijMXPmzLjzzjvjRz/6UdTV1Q3TQwAAJoq39T0uo6WzszPKysqio6PDe1wAIBEj8fPb7yoCAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZQwqXpqamqKqqipKSkqiuro7t27e/6fy1a9fGBz7wgTjxxBOjsrIyli1bFq+99tqQNgwATFx5h8umTZuivr4+GhoaYufOnTFz5syoq6uLl156adD5P/vZz2L58uXR0NAQu3fvjnvvvTc2bdoUN91009vePAAwseQdLnfddVdcffXVsWTJkvjQhz4U69evj5NOOinuu+++Qec//vjjceGFF8YVV1wRVVVV8alPfSouv/zyt3yWBgDgf+UVLj09PbFjx46ora397x0UFkZtbW20tLQMuuaCCy6IHTt29IfK3r17Y8uWLXHppZce9Trd3d3R2dk54AYAMCmfyQcOHIje3t4oLy8fMF5eXh579uwZdM0VV1wRBw4ciI997GORZVkcPnw4rr322jd9qaixsTFuvfXWfLYGAEwAI/6pom3btsXq1avj7rvvjp07d8ZDDz0Umzdvjttuu+2oa1asWBEdHR39t/3794/0NgGABOT1jMuUKVOiqKgo2tvbB4y3t7dHRUXFoGtuueWWWLhwYVx11VUREXHOOedEV1dXXHPNNbFy5cooLDyynXK5XORyuXy2BgBMAHk941JcXByzZ8+O5ubm/rG+vr5obm6OmpqaQde8+uqrR8RJUVFRRERkWZbvfgGACSyvZ1wiIurr62Px4sUxZ86cmDt3bqxduza6urpiyZIlERGxaNGimDFjRjQ2NkZExLx58+Kuu+6K8847L6qrq+O5556LW265JebNm9cfMAAAxyLvcFmwYEG8/PLLsWrVqmhra4tZs2bF1q1b+9+wu2/fvgHPsNx8881RUFAQN998c/ztb3+Ld73rXTFv3rz4zne+M3yPAgCYEAqyBF6v6ezsjLKysujo6IjS0tKx3g4AcAxG4ue331UEACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhhQuTU1NUVVVFSUlJVFdXR3bt29/0/kHDx6MpUuXxrRp0yKXy8WZZ54ZW7ZsGdKGAYCJa1K+CzZt2hT19fWxfv36qK6ujrVr10ZdXV0888wzMXXq1CPm9/T0xCc/+cmYOnVqPPjggzFjxoz4y1/+Eqeeeupw7B8AmEAKsizL8llQXV0d559/fqxbty4iIvr6+qKysjKuv/76WL58+RHz169fH9/73vdiz549ccIJJwxpk52dnVFWVhYdHR1RWlo6pPsAAEbXSPz8zuulop6entixY0fU1tb+9w4KC6O2tjZaWloGXfOrX/0qampqYunSpVFeXh5nn312rF69Onp7e496ne7u7ujs7BxwAwDIK1wOHDgQvb29UV5ePmC8vLw82traBl2zd+/eePDBB6O3tze2bNkSt9xyS9x5553x7W9/+6jXaWxsjLKysv5bZWVlPtsEAMapEf9UUV9fX0ydOjXuueeemD17dixYsCBWrlwZ69evP+qaFStWREdHR/9t//79I71NACABeb05d8qUKVFUVBTt7e0Dxtvb26OiomLQNdOmTYsTTjghioqK+sc++MEPRltbW/T09ERxcfERa3K5XORyuXy2BgBMAHk941JcXByzZ8+O5ubm/rG+vr5obm6OmpqaQddceOGF8dxzz0VfX1//2LPPPhvTpk0bNFoAAI4m75eK6uvrY8OGDfGTn/wkdu/eHdddd110dXXFkiVLIiJi0aJFsWLFiv751113Xbzyyitxww03xLPPPhubN2+O1atXx9KlS4fvUQAAE0Le3+OyYMGCePnll2PVqlXR1tYWs2bNiq1bt/a/YXffvn1RWPjfHqqsrIxHHnkkli1bFueee27MmDEjbrjhhrjxxhuH71EAABNC3t/jMhZ8jwsApGfMv8cFAGAsCRcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIxpDCpampKaqqqqKkpCSqq6tj+/btx7Ru48aNUVBQEPPnzx/KZQGACS7vcNm0aVPU19dHQ0ND7Ny5M2bOnBl1dXXx0ksvvem6F198Mb72ta/FRRddNOTNAgATW97hctddd8XVV18dS5YsiQ996EOxfv36OOmkk+K+++476pre3t74whe+ELfeemucfvrpb3mN7u7u6OzsHHADAMgrXHp6emLHjh1RW1v73zsoLIza2tpoaWk56rpvfetbMXXq1LjyyiuP6TqNjY1RVlbWf6usrMxnmwDAOJVXuBw4cCB6e3ujvLx8wHh5eXm0tbUNuuaxxx6Le++9NzZs2HDM11mxYkV0dHT03/bv35/PNgGAcWrSSN75oUOHYuHChbFhw4aYMmXKMa/L5XKRy+VGcGcAQIryCpcpU6ZEUVFRtLe3Dxhvb2+PioqKI+Y///zz8eKLL8a8efP6x/r6+v5z4UmT4plnnokzzjhjKPsGACagvF4qKi4ujtmzZ0dzc3P/WF9fXzQ3N0dNTc0R888666x48skno7W1tf/26U9/Oi655JJobW313hUAIC95v1RUX18fixcvjjlz5sTcuXNj7dq10dXVFUuWLImIiEWLFsWMGTOisbExSkpK4uyzzx6w/tRTT42IOGIcAOCt5B0uCxYsiJdffjlWrVoVbW1tMWvWrNi6dWv/G3b37dsXhYW+kBcAGH4FWZZlY72Jt9LZ2RllZWXR0dERpaWlY70dAOAYjMTPb0+NAADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJAM4QIAJEO4AADJEC4AQDKECwCQjCGFS1NTU1RVVUVJSUlUV1fH9u3bjzp3w4YNcdFFF8XkyZNj8uTJUVtb+6bzAQCOJu9w2bRpU9TX10dDQ0Ps3LkzZs6cGXV1dfHSSy8NOn/btm1x+eWXx+9///toaWmJysrK+NSnPhV/+9vf3vbmAYCJpSDLsiyfBdXV1XH++efHunXrIiKir68vKisr4/rrr4/ly5e/5fre3t6YPHlyrFu3LhYtWjTonO7u7uju7u7/c2dnZ1RWVkZHR0eUlpbms10AYIx0dnZGWVnZsP78zusZl56entixY0fU1tb+9w4KC6O2tjZaWlqO6T5effXVeP311+Md73jHUec0NjZGWVlZ/62ysjKfbQIA41Re4XLgwIHo7e2N8vLyAePl5eXR1tZ2TPdx4403xvTp0wfEz/9asWJFdHR09N/279+fzzYBgHFq0mhebM2aNbFx48bYtm1blJSUHHVeLpeLXC43ijsDAFKQV7hMmTIlioqKor29fcB4e3t7VFRUvOnaO+64I9asWRO//e1v49xzz81/pwDAhJfXS0XFxcUxe/bsaG5u7h/r6+uL5ubmqKmpOeq622+/PW677bbYunVrzJkzZ+i7BQAmtLxfKqqvr4/FixfHnDlzYu7cubF27dro6uqKJUuWRETEokWLYsaMGdHY2BgREd/97ndj1apV8bOf/Syqqqr63wtz8sknx8knnzyMDwUAGO/yDpcFCxbEyy+/HKtWrYq2traYNWtWbN26tf8Nu/v27YvCwv8+kfPDH/4wenp64rOf/eyA+2loaIhvfvObb2/3AMCEkvf3uIyFkfgcOAAwssb8e1wAAMaScAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkCBcAIBnCBQBIhnABAJIhXACAZAgXACAZwgUASIZwAQCSIVwAgGQIFwAgGcIFAEiGcAEAkiFcAIBkDClcmpqaoqqqKkpKSqK6ujq2b9/+pvMfeOCBOOuss6KkpCTOOeec2LJly5A2CwBMbHmHy6ZNm6K+vj4aGhpi586dMXPmzKirq4uXXnpp0PmPP/54XH755XHllVfGrl27Yv78+TF//vx46qmn3vbmAYCJpSDLsiyfBdXV1XH++efHunXrIiKir68vKisr4/rrr4/ly5cfMX/BggXR1dUVv/71r/vHPvrRj8asWbNi/fr1g16ju7s7uru7+//c0dERp512Wuzfvz9KS0vz2S4AMEY6OzujsrIyDh48GGVlZcNyn5PymdzT0xM7duyIFStW9I8VFhZGbW1ttLS0DLqmpaUl6uvrB4zV1dXFL3/5y6Nep7GxMW699dYjxisrK/PZLgBwHPjHP/4xNuFy4MCB6O3tjfLy8gHj5eXlsWfPnkHXtLW1DTq/ra3tqNdZsWLFgNg5ePBgvOc974l9+/YN2wNnaN6oZ89+jT1ncfxwFscX53H8eOMVk3e84x3Ddp95hctoyeVykcvljhgvKyvzD+FxorS01FkcJ5zF8cNZHF+cx/GjsHD4PsSc1z1NmTIlioqKor29fcB4e3t7VFRUDLqmoqIir/kAAEeTV7gUFxfH7Nmzo7m5uX+sr68vmpubo6amZtA1NTU1A+ZHRDz66KNHnQ8AcDR5v1RUX18fixcvjjlz5sTcuXNj7dq10dXVFUuWLImIiEWLFsWMGTOisbExIiJuuOGGuPjii+POO++Myy67LDZu3BhPPPFE3HPPPcd8zVwuFw0NDYO+fMTochbHD2dx/HAWxxfncfwYibPI++PQERHr1q2L733ve9HW1hazZs2K73//+1FdXR0RER//+Mejqqoq7r///v75DzzwQNx8883x4osvxvvf//64/fbb49JLLx22BwEATAxDChcAgLHgdxUBAMkQLgBAMoQLAJAM4QIAJOO4CZempqaoqqqKkpKSqK6uju3bt7/p/AceeCDOOuusKCkpiXPOOSe2bNkySjsd//I5iw0bNsRFF10UkydPjsmTJ0dtbe1bnh3HLt+/F2/YuHFjFBQUxPz580d2gxNIvmdx8ODBWLp0aUybNi1yuVyceeaZ/j01TPI9i7Vr18YHPvCBOPHEE6OysjKWLVsWr7322ijtdvz6wx/+EPPmzYvp06dHQUHBm/4Owjds27YtPvKRj0Qul4v3ve99Az6BfMyy48DGjRuz4uLi7L777sv+/Oc/Z1dffXV26qmnZu3t7YPO/+Mf/5gVFRVlt99+e/b0009nN998c3bCCSdkTz755CjvfPzJ9yyuuOKKrKmpKdu1a1e2e/fu7Itf/GJWVlaW/fWvfx3lnY8/+Z7FG1544YVsxowZ2UUXXZR95jOfGZ3NjnP5nkV3d3c2Z86c7NJLL80ee+yx7IUXXsi2bduWtba2jvLOx598z+KnP/1plsvlsp/+9KfZCy+8kD3yyCPZtGnTsmXLlo3yzsefLVu2ZCtXrsweeuihLCKyhx9++E3n7927NzvppJOy+vr67Omnn85+8IMfZEVFRdnWrVvzuu5xES5z587Nli5d2v/n3t7ebPr06VljY+Og8z/3uc9ll1122YCx6urq7Etf+tKI7nMiyPcs/tfhw4ezU045JfvJT34yUlucMIZyFocPH84uuOCC7Ec/+lG2ePFi4TJM8j2LH/7wh9npp5+e9fT0jNYWJ4x8z2Lp0qXZJz7xiQFj9fX12YUXXjii+5xojiVcvvGNb2Qf/vCHB4wtWLAgq6ury+taY/5SUU9PT+zYsSNqa2v7xwoLC6O2tjZaWloGXdPS0jJgfkREXV3dUedzbIZyFv/r1Vdfjddff31YfxPoRDTUs/jWt74VU6dOjSuvvHI0tjkhDOUsfvWrX0VNTU0sXbo0ysvL4+yzz47Vq1dHb2/vaG17XBrKWVxwwQWxY8eO/peT9u7dG1u2bPElqGNguH52j/lvhz5w4ED09vZGeXn5gPHy8vLYs2fPoGva2toGnd/W1jZi+5wIhnIW/+vGG2+M6dOnH/EPJ/kZylk89thjce+990Zra+so7HDiGMpZ7N27N373u9/FF77whdiyZUs899xz8eUvfzlef/31aGhoGI1tj0tDOYsrrrgiDhw4EB/72Mciy7I4fPhwXHvttXHTTTeNxpb5f472s7uzszP+/e9/x4knnnhM9zPmz7gwfqxZsyY2btwYDz/8cJSUlIz1diaUQ4cOxcKFC2PDhg0xZcqUsd7OhNfX1xdTp06Ne+65J2bPnh0LFiyIlStXxvr168d6axPOtm3bYvXq1XH33XfHzp0746GHHorNmzfHbbfdNtZbY4jG/BmXKVOmRFFRUbS3tw8Yb29vj4qKikHXVFRU5DWfYzOUs3jDHXfcEWvWrInf/va3ce65547kNieEfM/i+eefjxdffDHmzZvXP9bX1xcREZMmTYpnnnkmzjjjjJHd9Dg1lL8X06ZNixNOOCGKior6xz74wQ9GW1tb9PT0RHFx8YjuebwaylnccsstsXDhwrjqqqsiIuKcc86Jrq6uuOaaa2LlypVRWOi/30fL0X52l5aWHvOzLRHHwTMuxcXFMXv27Ghubu4f6+vri+bm5qipqRl0TU1NzYD5ERGPPvroUedzbIZyFhERt99+e9x2222xdevWmDNnzmhsddzL9yzOOuusePLJJ6O1tbX/9ulPfzouueSSaG1tjcrKytHc/rgylL8XF154YTz33HP98RgR8eyzz8a0adNEy9swlLN49dVXj4iTN4Iy86v6RtWw/ezO733DI2Pjxo1ZLpfL7r///uzpp5/OrrnmmuzUU0/N2trasizLsoULF2bLly/vn//HP/4xmzRpUnbHHXdku3fvzhoaGnwcepjkexZr1qzJiouLswcffDD7+9//3n87dOjQWD2EcSPfs/hfPlU0fPI9i3379mWnnHJK9pWvfCV75plnsl//+tfZ1KlTs29/+9tj9RDGjXzPoqGhITvllFOyn//859nevXuz3/zmN9kZZ5yRfe5znxurhzBuHDp0KNu1a1e2a9euLCKyu+66K9u1a1f2l7/8JcuyLFu+fHm2cOHC/vlvfBz661//erZ79+6sqakp3Y9DZ1mW/eAHP8hOO+20rLi4OJs7d272pz/9qf9/u/jii7PFixcPmP+LX/wiO/PMM7Pi4uLswx/+cLZ58+ZR3vH4lc9ZvOc978ki4ohbQ0PD6G98HMr378X/J1yGV75n8fjjj2fV1dVZLpfLTj/99Ow73/lOdvjw4VHe9fiUz1m8/vrr2Te/+c3sjDPOyEpKSrLKysrsy1/+cvbPf/5z9Dc+zvz+978f9N//b/z/v3jx4uziiy8+Ys2sWbOy4uLi7PTTT89+/OMf533dgizzXBkAkIYxf48LAMCxEi4AQDKECwCQDOECACRDuAAAyRAuAEAyhAsAkAzhAgAkQ7gAAMkQLgBAMoQLAJCM/wM9kKRvAVrZIAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "order = [] \n",
+    "eg_time = []\n",
+    "mo_time = []\n",
+    "delta = 3600.\n",
+    "\n",
+    "for k in results[delta]:\n",
+    "    order.append(k)\n",
+    "    eg_time.append(results[delta][k]['lift_event_graph_time'])\n",
+    "    mo_time.append(results[delta][k]['mo_time']-results[delta][k]['lift_event_graph_time'])\n",
+    "sns.lineplot(x=order, y=eg_time, label='event graph')\n",
+    "sns.lineplot(x=order, y=mo_time, label='order lifting')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "base",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/pathpyG/io/netzschleuder.py
+++ b/src/pathpyG/io/netzschleuder.py
@@ -92,7 +92,8 @@ def read_netzschleuder_record(name: str, base_url: str = 'https://networks.skewe
 
 
 def read_netzschleuder_graph(name: str, net: Optional[str] = None, multiedges: bool = False,
-        base_url: str='https://networks.skewed.de', format='csv') -> Graph:
+                             time_attr: Optional[str] = None,
+                             base_url: str = 'https://networks.skewed.de', format='csv') -> Graph:
     """Read a pathpyG graph or temporal graph from the netzschleuder repository.
 
     Args:
@@ -140,7 +141,7 @@ def read_netzschleuder_graph(name: str, net: Optional[str] = None, multiedges: b
         except KeyError:
             raise Exception(f'Record {name} contains multiple networks, please specify network name.')
         
-        if format == 'csv': 
+        if format == 'csv':
             url = f'{base_url}/net/{name}/files/{net}.csv.zip'
             try:
                 response = request.urlopen(url)
@@ -160,8 +161,8 @@ def read_netzschleuder_graph(name: str, net: Optional[str] = None, multiedges: b
 
                         # rename columns
                         edges.rename(columns={'# source': 'v', 'target': 'w'}, inplace=True)
-                        if timestamps:
-                            edges.rename(columns={'time': 't'}, inplace=True)
+                        if timestamps and time_attr:
+                            edges.rename(columns={time_attr: 't'}, inplace=True)
 
                         # construct graph and assign edge attributes
                         if timestamps:

--- a/tests/io/test_netzschleuder.py
+++ b/tests/io/test_netzschleuder.py
@@ -58,7 +58,7 @@ def test_read_netzschleuder_record():
 def test_read_netzschleuder_graph_temporal():
     """Test the read_netzschleuder_graph() function for timestamped data."""
 
-    g = read_netzschleuder_graph(name="email_company")
+    g = read_netzschleuder_graph(name="email_company", time_attr='time')
     assert isinstance(g, TemporalGraph)
     assert g.N == 167
     assert g.M == 82927


### PR DESCRIPTION
- Fixes issue when reading netzschleuder records that use timestamp attributes that are not called `time`
- Improved performance of lift_order_temporal (Dagstuhl night session, Moritz and Ingo)