### PR TITLE
add logging functionality (#32)

### DIFF
--- a/src/pathpyG/__init__.py
+++ b/src/pathpyG/__init__.py
@@ -16,6 +16,7 @@ __version__ = "0.1.0"
 
 from pathpyG.utils.config import config
 from pathpyG.utils.progress import tqdm
+from pathpyG.utils.logger import logger
 
 from pathpyG.core.graph import Graph
 from pathpyG.core.index_map import IndexMap

--- a/src/pathpyG/logging.toml
+++ b/src/pathpyG/logging.toml
@@ -1,0 +1,37 @@
+[loggers]
+keys=root,pathpyg
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=simpleFormatter, customFormatter
+
+[logger_root]
+level=ERROR
+handlers=consoleHandler,fileHandler
+
+[logger_pathpyg]
+level=INFO
+handlers=consoleHandler,fileHandler
+qualname=pathpyg
+propagate=0
+
+[handler_fileHandler]
+class=FileHandler
+level=DEBUG
+formatter=customFormatter
+args=('pathpyG.log', )
+
+[handler_consoleHandler]
+class=StreamHandler
+level=DEBUG
+formatter=customFormatter
+args=(sys.stdout,)
+
+[formatter_simpleFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+
+[formatter_customFormatter]
+format=%(asctime)s - %(message)s
+datefmt=%Y-%m-%d %H:%M:%S

--- a/src/pathpyG/utils/logger.py
+++ b/src/pathpyG/utils/logger.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python -tt
+# -*- coding: utf-8 -*-
+# =============================================================================
+# File      : logger.py -- Module to log comments
+# Author    : Jürgen Hackl <hackl@princeton.edu>
+# Time-stamp: <Thu 2024-11-14 12:09 juergen>
+#
+# Copyright (c) 2016-2019 Pathpy Developers
+# =============================================================================
+import os
+import sys
+import logging.config
+from pathlib import Path
+
+
+# path to the module
+path = Path(sys.modules[__name__].__file__).resolve().parents[1]
+
+# default logging config file name
+loggingfile_name = "logging.toml"
+
+# check if local logging config file is defined
+if os.path.exists(os.path.join(os.getcwd(), loggingfile_name)):
+    # get location of local config file
+    loggingfile_path = os.path.join(os.getcwd(), loggingfile_name)
+else:
+    # get location of default config file
+    loggingfile_path = os.path.join(path, loggingfile_name)
+
+# update logging confing
+logging.config.fileConfig(loggingfile_path)
+
+# create logger
+logger = logging.getLogger("pathpyg")
+
+# Status message of the logger
+logger.debug("Logger successful initialized.")


### PR DESCRIPTION
Add functionality to log events in the console or in the `.log` file.

logger can be accessed via:

```python
from pathpyG.utils.logger import logger
logger.info("Info Text")
```

or created by default logger module

```python
import pathpyG as pp
import logging

logger = logging.getLogger("pathpyg")
logger.info("Info Text")
```

The default logger config is stored in the src pathpyG folder under `logging.toml` and can be replaced with a local `logging.toml` config in the working directory.