### PR TITLE
Fix: Sparse Adjancency too small if graph contains isolated nodes

### DIFF
--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -390,7 +390,7 @@ class Graph:
             scipy.sparse.coo_matrix: sparse adjacency matrix representation of graph
         """
         if edge_attr is None:
-            return torch_geometric.utils.to_scipy_sparse_matrix(self.data.edge_index.as_tensor())
+            return torch_geometric.utils.to_scipy_sparse_matrix(self.data.edge_index.as_tensor(), num_nodes=self.n)
         else:
             return torch_geometric.utils.to_scipy_sparse_matrix(
                 self.data.edge_index.as_tensor(), edge_attr=self.data[edge_attr], num_nodes=self.n

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -204,6 +204,16 @@ def test_sparse_adj_matrix(simple_graph):
     assert weighted_adj.data[1] == 1
     assert weighted_adj.data[2] == 2
 
+    g = Graph.from_edge_index(torch.tensor([[0], [1]]), num_nodes=5)
+    adj = g.sparse_adj_matrix()
+    assert adj.shape == (5, 5)
+    assert adj.nnz == 1
+
+    g.data.edge_attr = torch.tensor([[1]])
+    adj = g.sparse_adj_matrix("edge_attr")
+    assert adj.shape == (5, 5)
+    assert adj.nnz == 1
+
 
 def test_degrees(simple_graph):
     in_degrees = simple_graph.degrees("in")


### PR DESCRIPTION
Fixed a bug where the size of the sparse adjacency matrix did not correspond to the number of nodes if the graph contained isolated nodes. A test case is added that failed before the fix.