### PR TITLE
Fix Dev Deployment Issue

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,7 @@ plugins:
               annotations_path: full
               show_bases: True
               show_signature: False
-            import:
+            inventories:
               - https://docs.python.org/3/objects.inv
               - https://docs.scipy.org/doc/scipy/objects.inv
               - https://numpy.org/doc/stable/objects.inv


### PR DESCRIPTION
Upgrading to Python 3.13 led to a problem in the MKDocs Config since the config parameter `import` was renamed to `inventories. This was fixed.