### PR TITLE
Forcing DVI output

### DIFF
--- a/src/pathpyG/visualisations/_tikz/backend.py
+++ b/src/pathpyG/visualisations/_tikz/backend.py
@@ -225,6 +225,7 @@ class TikzBackend(PlotBackend):
         # latex compiler
         command = [
             "latexmk",
+            "-dvi",
             "--interaction=nonstopmode",
             "default.tex",
         ]


### PR DESCRIPTION
Local testing was failing for me because one of the commands is assuming a `dvi` output (which a later step consumes) without specifying its flag explicitly. This seems to be working on the CI but was failing in my case - the code assumes latexmk's default target is DVI, but my local `latexmk` defaults to PDF. 

This tweak should fix it for the general case.