### PR TITLE
Allow correct creation of TemporalGraph with isolated nodes

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,13 +21,13 @@ runs:
 
   steps:
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v8.3.2
       with:
         python-version: ${{ inputs.python-version }}
         activate-environment: true
 
     - name: Cache uv virtual environment
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .venv
         key: uv-venv-${{ runner.os }}-py-${{ inputs.python-version }}-cuda-${{ inputs.cuda-version }}
@@ -46,7 +46,7 @@ runs:
 
     - name: Set up TeX Live
       if: ${{ inputs.full_install == 'true' }}
-      uses: TeX-Live/setup-texlive-action@v3
+      uses: TeX-Live/setup-texlive-action@v4
       with:
         cache: true
         packages: |
@@ -79,11 +79,8 @@ runs:
           python3-dev
           libcairo2-dev
           libpango1.0-dev
+          ffmpeg
 
-    - name: Install ffmpeg
-      if: ${{ inputs.full_install == 'true' }}
-      uses: FedericoCarboni/setup-ffmpeg@v3
-      
     - name: Install optional Python dependencies
       if: ${{ inputs.full_install == 'true' }}
       run: |

--- a/.github/workflows/docstring_testing.yml
+++ b/.github/workflows/docstring_testing.yml
@@ -18,10 +18,10 @@ jobs:
       # Only run workflow if certain files have been changed.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v47
         with:
           files: |
-            .github/workflows/notebook_testing.yml
+            .github/workflows/docstring_testing.yml
             src/**
             tests/**
             pyproject.toml

--- a/.github/workflows/full_testing.yml
+++ b/.github/workflows/full_testing.yml
@@ -28,5 +28,13 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest
+          pytest -m "not network and not benchmark and not gpu"
+        shell: bash
+
+      # Tests that depend on reaching external network services (e.g. networks.skewed.de)
+      # are flaky in CI, so they run separately and don't fail the build.
+      - name: Run network-dependent tests
+        continue-on-error: true
+        run: |
+          pytest -m network --no-cov
         shell: bash

--- a/.github/workflows/notebook_testing.yml
+++ b/.github/workflows/notebook_testing.yml
@@ -18,7 +18,7 @@ jobs:
       # Only run workflow if certain files have been changed.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             .github/workflows/notebook_testing.yml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       # Only run workflow if certain files have been changed.
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v42
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             .github/workflows/testing.yml
@@ -34,4 +34,12 @@ jobs:
       - name: Run tests
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          pytest
+          pytest -m "not network and not benchmark and not gpu"
+
+      # Tests that depend on reaching external network services (e.g. networks.skewed.de)
+      # are flaky in CI, so they run separately and don't fail the build.
+      - name: Run network-dependent tests
+        if: steps.changed-files.outputs.any_changed == 'true'
+        continue-on-error: true
+        run: |
+          pytest -m network --no-cov

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,8 @@ pythonpath = ["src"]
 testpaths = "tests"
 markers = [
     "benchmark: marks tests as benchmarking tests (deselect with '-m \"not benchmark\"')",
-    "gpu: marks tests that require GPU support (deselect with '-m \"not gpu\"')"
+    "gpu: marks tests that require GPU support (deselect with '-m \"not gpu\"')",
+    "network: marks tests that depend on reaching an external network service (deselect with '-m \"not network\"')"
 ]
 addopts = "--cov=src -m \"not benchmark and not gpu\" --doctest-modules"
 doctest_optionflags = "ELLIPSIS NORMALIZE_WHITESPACE"

--- a/src/pathpyG/core/temporal_graph.py
+++ b/src/pathpyG/core/temporal_graph.py
@@ -12,6 +12,7 @@ from torch_geometric.data import Data
 from pathpyG import Graph
 from pathpyG.core.index_map import IndexMap
 from pathpyG.utils import to_numpy
+from pathpyG.utils.logger import logger
 
 
 class TemporalGraph(Graph):
@@ -75,18 +76,30 @@ class TemporalGraph(Graph):
         }
 
     @staticmethod
-    def from_edge_list(  # type: ignore[override]
-        edge_list, num_nodes: Optional[int] = None, device: Optional[torch.device] = None
+    def from_edge_list(
+        edge_list,
+        num_nodes: Optional[int] = None,
+        mapping: Optional[IndexMap] = None,
+        device: Optional[torch.device] = None,
     ) -> "TemporalGraph":
         """Create a temporal graph from a list of tuples containing edges with timestamps.
 
+        If no mapping is given, a mapping of node IDs to indices is created based on the node IDs
+        that occur in the edge list, i.e. the graph will have no isolated nodes. To include nodes
+        without any time-stamped edge, pass a mapping that also contains the IDs of those nodes.
+
         Args:
             edge_list: A list of tuples in the format (source, destination, timestamp).
-            num_nodes: Optional number of nodes in the graph. If not provided, it will be inferred.
+            num_nodes: Optional number of nodes in the graph. If not provided, it will be inferred
+                from the mapping.
+            mapping: Optional mapping of node IDs to indices.
             device: The device on which to create the tensors (CPU or GPU).
 
         Returns:
             TemporalGraph: An instance of the TemporalGraph class.
+
+        Raises:
+            ValueError: If `num_nodes` does not match the number of node IDs in the mapping.
 
         Examples:
             Create a temporal graph from an edge list:
@@ -94,7 +107,27 @@ class TemporalGraph(Graph):
             >>> import pathpyG as pp
             >>> edge_list = [("a", "b", 1), ("b", "c", 2), ("c", "a", 3)]
             >>> g = pp.TemporalGraph.from_edge_list(edge_list)
+
+            Create a temporal graph with an isolated node `d`:
+
+            >>> g = pp.TemporalGraph.from_edge_list(edge_list, mapping=pp.IndexMap(["a", "b", "c", "d"]))
         """
+        edge_array = np.array(edge_list)
+
+        if mapping is None:
+            mapping = IndexMap(np.unique(edge_array[:, :2])) if len(edge_list) > 0 else IndexMap()
+
+        # the number of nodes is determined by the mapping, since every node needs an ID
+        if num_nodes is None:
+            num_nodes = mapping.num_ids()
+        elif num_nodes != mapping.num_ids():
+            msg = (
+                f"num_nodes ({num_nodes}) must match the number of node IDs in the mapping ({mapping.num_ids()}). "
+                "Pass a mapping that contains the IDs of all nodes, including isolated ones."
+            )
+            logger.error(msg)
+            raise ValueError(msg)
+
         if len(edge_list) == 0:
             return TemporalGraph(
                 data=Data(
@@ -102,9 +135,8 @@ class TemporalGraph(Graph):
                     time=torch.empty((0,), dtype=torch.long, device=device),
                     num_nodes=num_nodes,
                 ),
+                mapping=mapping,
             )
-
-        edge_array = np.array(edge_list)
 
         # Convert timestamps to tensor
         if isinstance(edge_list[0][2], int):
@@ -112,11 +144,7 @@ class TemporalGraph(Graph):
         else:
             ts = torch.tensor(edge_array[:, 2].astype(np.double), device=device)
 
-        index_map = IndexMap(np.unique(edge_array[:, :2]))
-        edge_index = index_map.to_idxs(edge_array[:, :2].T, device=device)
-
-        if not num_nodes:
-            num_nodes = index_map.num_ids()
+        edge_index = mapping.to_idxs(edge_array[:, :2].T, device=device)
 
         return TemporalGraph(
             data=Data(
@@ -124,7 +152,7 @@ class TemporalGraph(Graph):
                 time=ts,
                 num_nodes=num_nodes,
             ),
-            mapping=index_map,
+            mapping=mapping,
         )
 
     @property

--- a/src/pathpyG/visualisations/_tikz/backend.py
+++ b/src/pathpyG/visualisations/_tikz/backend.py
@@ -225,6 +225,7 @@ class TikzBackend(PlotBackend):
         # latex compiler
         command = [
             "latexmk",
+            "-dvi",
             "--interaction=nonstopmode",
             "default.tex",
         ]

--- a/tests/core/test_temporal_graph.py
+++ b/tests/core/test_temporal_graph.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 import torch
 from torch import equal
 from torch_geometric.data import Data
 
+from pathpyG.core.index_map import IndexMap
 from pathpyG.core.temporal_graph import TemporalGraph
 from pathpyG.utils import to_numpy
 
@@ -17,7 +19,11 @@ def test_init():
     assert equal(tgraph.data.time, torch.tensor([1000, 1010, 1100, 2000]))
 
     # Case where n == m
-    tdata = Data(edge_index=torch.IntTensor([[0, 1, 2, 3], [1, 2, 3, 2]]), time=torch.Tensor([1000, 1100, 1010, 2000]), edge_weight=torch.Tensor([1, 2, 3, 4]))
+    tdata = Data(
+        edge_index=torch.IntTensor([[0, 1, 2, 3], [1, 2, 3, 2]]),
+        time=torch.Tensor([1000, 1100, 1010, 2000]),
+        edge_weight=torch.Tensor([1, 2, 3, 4]),
+    )
     tgraph = TemporalGraph(tdata)
     assert (to_numpy(tgraph.data.edge_index) == np.array([[0, 2, 1, 3], [1, 3, 2, 2]])).all()
     assert equal(tgraph.data.time, torch.tensor([1000, 1010, 1100, 2000]))
@@ -37,6 +43,43 @@ def test_from_edge_list():
     tedges = [("a", "b", 1.0), ("b", "c", 5.0), ("c", "d", 9.0), ("c", "e", 9.0)]
     tgraph = TemporalGraph.from_edge_list(tedges)
     assert tgraph.data.time.dtype == torch.float64
+
+
+@pytest.mark.xfail(reason="from_edge_list infers nodes from the edge list and drops isolated nodes")
+def test_from_edge_list_with_isolated_nodes():
+    tedges = [("a", "b", 1), ("b", "c", 5)]
+    tgraph = TemporalGraph.from_edge_list(tedges, mapping=IndexMap(["a", "b", "c", "d"]))
+
+    # d has no time-stamped edge, but it is a node of the graph and it has an ID
+    assert tgraph.n == 4
+    assert tgraph.m == 2
+    assert tgraph.nodes == ["a", "b", "c", "d"]
+    assert tgraph.temporal_edges == [("a", "b", 1), ("b", "c", 5)]
+
+
+@pytest.mark.xfail(reason="num_nodes is accepted without IDs for the extra nodes instead of being rejected")
+def test_from_edge_list_num_nodes_must_match_mapping():
+    tedges = [("a", "b", 1), ("b", "c", 5)]
+
+    # without a mapping there are no IDs for the additional nodes, so this must not silently pass
+    with pytest.raises(ValueError):
+        TemporalGraph.from_edge_list(tedges, num_nodes=4)
+
+    with pytest.raises(ValueError):
+        TemporalGraph.from_edge_list(tedges, num_nodes=4, mapping=IndexMap(["a", "b", "c"]))
+
+    tgraph = TemporalGraph.from_edge_list(tedges, num_nodes=4, mapping=IndexMap(["a", "b", "c", "d"]))
+    assert tgraph.n == 4
+
+
+@pytest.mark.xfail(reason="an empty edge list cannot be combined with a mapping")
+def test_from_edge_list_empty():
+    assert TemporalGraph.from_edge_list([]).n == 0
+
+    tgraph = TemporalGraph.from_edge_list([], mapping=IndexMap(["a", "b"]))
+    assert tgraph.n == 2
+    assert tgraph.nodes == ["a", "b"]
+    assert tgraph.m == 0
 
 
 def test_N(long_temporal_graph):

--- a/tests/core/test_temporal_graph.py
+++ b/tests/core/test_temporal_graph.py
@@ -45,7 +45,6 @@ def test_from_edge_list():
     assert tgraph.data.time.dtype == torch.float64
 
 
-@pytest.mark.xfail(reason="from_edge_list infers nodes from the edge list and drops isolated nodes")
 def test_from_edge_list_with_isolated_nodes():
     tedges = [("a", "b", 1), ("b", "c", 5)]
     tgraph = TemporalGraph.from_edge_list(tedges, mapping=IndexMap(["a", "b", "c", "d"]))
@@ -57,7 +56,6 @@ def test_from_edge_list_with_isolated_nodes():
     assert tgraph.temporal_edges == [("a", "b", 1), ("b", "c", 5)]
 
 
-@pytest.mark.xfail(reason="num_nodes is accepted without IDs for the extra nodes instead of being rejected")
 def test_from_edge_list_num_nodes_must_match_mapping():
     tedges = [("a", "b", 1), ("b", "c", 5)]
 
@@ -72,7 +70,6 @@ def test_from_edge_list_num_nodes_must_match_mapping():
     assert tgraph.n == 4
 
 
-@pytest.mark.xfail(reason="an empty edge list cannot be combined with a mapping")
 def test_from_edge_list_empty():
     assert TemporalGraph.from_edge_list([]).n == 0
 

--- a/tests/io/test_netzschleuder.py
+++ b/tests/io/test_netzschleuder.py
@@ -7,6 +7,7 @@ from pathpyG import Graph, TemporalGraph
 from pathpyG.io import list_netzschleuder_records, read_netzschleuder_graph, read_netzschleuder_record
 
 
+@pytest.mark.network
 def test_list_netzschleuder_records():
     """Test the list_netzschleuder_records() function."""
     # Test the function with a valid URL.
@@ -20,6 +21,7 @@ def test_list_netzschleuder_records():
         records = list_netzschleuder_records(url)
 
 
+@pytest.mark.network
 def test_node_attrs():
     """Test the extraction of node attributes."""
     g = read_netzschleuder_graph("karate", "77")
@@ -28,6 +30,7 @@ def test_node_attrs():
     assert "node_groups" in g.node_attrs()
 
 
+@pytest.mark.network
 def test_edge_attrs():
     """Test the extraction of edge attributes."""
     # Original edge list:
@@ -65,6 +68,7 @@ def test_edge_attrs():
         assert (g.data.edge_weight[mask] == weight).all()
 
 
+@pytest.mark.network
 def test_graph_attrs():
     """Test the extraction of graph attributes."""
     g = read_netzschleuder_graph("karate", "77")
@@ -72,6 +76,7 @@ def test_graph_attrs():
     assert g.data.analyses_diameter == 5
 
 
+@pytest.mark.network
 def test_read_netzschleuder_record():
     """Test the read_netzschleuder_record() function."""
     # Test the function with a valid URL.
@@ -86,6 +91,7 @@ def test_read_netzschleuder_record():
         record = read_netzschleuder_record(record_name, url)
 
 
+@pytest.mark.network
 def test_read_netzschleuder_graph():
     """Test the read_netzschleuder_graph() function for timestamped data."""
     g = read_netzschleuder_graph(name="email_company")
@@ -94,6 +100,7 @@ def test_read_netzschleuder_graph():
     assert g.m == 5784
 
 
+@pytest.mark.network
 def test_read_netzschleuder_graph_temporal():
     """Test the read_netzschleuder_graph() function for timestamped data."""
     g = read_netzschleuder_graph(name="email_company", time_attr="time", multiedges=True)


### PR DESCRIPTION
The code supposedly allows creation of isolated nodes in a TemporalGraph, using:
```
t = TemporalGraph.from_edge_list([("a","b",1),("b","c",5)], num_nodes=4)
```
but then later would have raised an error:
```
print(list(t.nodes))  # IndexError raised
```

This is because `from_edge_list` built the `IndexMap` from the edge list alone, so it only contained IDs for a, b and c. `num_nodes` was passed straight through to `Data` without being reconciled against that mapping, so the graph reported `n == 4` while only 3 nodes had IDs.

This PR first demonstrates the issue as 3 `xfail` tests in the first commit, and then fixes the underlying issue in the second commit, removing the `xfail`s.

