### PR TITLE
Fixes for isolated nodes in Graph/TemporalGraph

### DIFF
--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -129,8 +129,9 @@ class Graph:
         Args:
             edge_index:  torch.Tensor or torch_geometric.EdgeIndex object containing an edge_index
             mapping: `IndexMap` object that maps node indices to string identifiers
-            num_nodes: optional number of nodes (default: None). If None, the number of nodes will be
-                inferred based on the maximum node index in the edge index, i.e. there will be no isolated nodes.
+            num_nodes: optional number of nodes (default: None). If None, the number of nodes is taken
+                from `mapping`, or - if no mapping is given - inferred based on the maximum node index in
+                the edge index, i.e. there will be no isolated nodes.
 
         Examples:
             You can create a graph from an edge index tensor as follows:
@@ -150,6 +151,9 @@ class Graph:
             b -> 1
             c -> 2
         """
+        if num_nodes is None and mapping is not None:
+            num_nodes = mapping.num_ids()
+
         if not num_nodes:
             d = Data(edge_index=edge_index)
         else:

--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -26,6 +26,21 @@ from pathpyG.core.index_map import IndexMap
 logger = logging.getLogger("root")
 
 
+def infer_mapping(edge_array: np.ndarray) -> IndexMap:
+    """Infer an `IndexMap` from the node IDs occurring in an array of edges.
+
+    IDs are ordered lexicographically, except for IDs that are entirely numeric strings,
+    which are ordered numerically so that e.g. `2` precedes `10`.
+
+    Args:
+        edge_array: array of edges whose entries are node IDs.
+    """
+    node_ids = np.unique(edge_array)
+    if np.issubdtype(node_ids.dtype, str) and np.char.isnumeric(node_ids).all():
+        node_ids = np.sort(node_ids.astype(int)).astype(str)
+    return IndexMap(node_ids)
+
+
 class Graph:
     """A graph object storing nodes, edges, and attributes.
 
@@ -197,11 +212,7 @@ class Graph:
             )
 
         if mapping is None:
-            edge_array = np.array(edge_list)
-            node_ids = np.unique(edge_array)
-            if np.issubdtype(node_ids.dtype, str) and np.char.isnumeric(node_ids).all():
-                node_ids = np.sort(node_ids.astype(int)).astype(str)
-            mapping = IndexMap(node_ids)
+            mapping = infer_mapping(np.array(edge_list))
 
         num_nodes = mapping.num_ids()
 

--- a/src/pathpyG/core/temporal_graph.py
+++ b/src/pathpyG/core/temporal_graph.py
@@ -1,6 +1,6 @@
 """Temporal Graph class for handling time-stamped edges."""
 
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -10,6 +10,7 @@ from torch_geometric import EdgeIndex
 from torch_geometric.data import Data
 
 from pathpyG import Graph
+from pathpyG.core.graph import infer_mapping
 from pathpyG.core.index_map import IndexMap
 from pathpyG.utils import to_numpy
 
@@ -56,9 +57,15 @@ class TemporalGraph(Graph):
         # reorder temporal data
         # Note that we do not use `torch_geometric.self.data.Data.sort_by_time` because it cannot sort numpy arrays`
         sorted_idx = torch.argsort(self.data.time)
+        # slicing an EdgeIndex discards its metadata, so restore it after reordering
+        is_undirected = self.data.edge_index.is_undirected
         for edge_attr in set(self.data.edge_attrs()).union(set(["time"])):
             if edge_attr == "edge_index":
-                self.data.edge_index = self.data.edge_index[:, sorted_idx]
+                self.data.edge_index = EdgeIndex(
+                    data=self.data.edge_index[:, sorted_idx].as_tensor(),
+                    sparse_size=(self.data.num_nodes, self.data.num_nodes),
+                    is_undirected=is_undirected,
+                )
             else:
                 self.data[edge_attr] = self.data[edge_attr][sorted_idx]
 
@@ -75,14 +82,22 @@ class TemporalGraph(Graph):
         }
 
     @staticmethod
-    def from_edge_list(  # type: ignore[override]
-        edge_list, num_nodes: Optional[int] = None, device: Optional[torch.device] = None
+    def from_edge_list(  # type: ignore[override]  # temporal edges carry a timestamp, unlike those of `Graph`
+        edge_list: Iterable[Tuple[str, str, Union[int, float]]],
+        is_undirected: bool = False,
+        mapping: Optional[IndexMap] = None,
+        device: Optional[torch.device] = None,
     ) -> "TemporalGraph":
         """Create a temporal graph from a list of tuples containing edges with timestamps.
 
+        Edges can be given as string or integer tuples. If strings are used and no mapping is given,
+        a mapping of node IDs to indices will be automatically created based on a lexicographic ordering of
+        node IDs. Nodes that are contained in the mapping but not in any edge will be isolated nodes.
+
         Args:
-            edge_list: A list of tuples in the format (source, destination, timestamp).
-            num_nodes: Optional number of nodes in the graph. If not provided, it will be inferred.
+            edge_list: Iterable of temporal edges in the format (source, destination, timestamp).
+            is_undirected: Whether the edge list contains all bidirectional edges
+            mapping: optional mapping of string IDs to node indices
             device: The device on which to create the tensors (CPU or GPU).
 
         Returns:
@@ -95,28 +110,35 @@ class TemporalGraph(Graph):
             >>> edge_list = [("a", "b", 1), ("b", "c", 2), ("c", "a", 3)]
             >>> g = pp.TemporalGraph.from_edge_list(edge_list)
         """
-        if len(edge_list) == 0:
+        # handle empty graph
+        if len(edge_list) == 0:  # type: ignore[arg-type]
             return TemporalGraph(
                 data=Data(
                     edge_index=torch.empty((2, 0), dtype=torch.long, device=device),
                     time=torch.empty((0,), dtype=torch.long, device=device),
-                    num_nodes=num_nodes,
+                    num_nodes=0 if mapping is None else mapping.num_ids(),
                 ),
+                mapping=IndexMap() if mapping is None else mapping,
             )
 
         edge_array = np.array(edge_list)
 
         # Convert timestamps to tensor
-        if isinstance(edge_list[0][2], int):
+        if isinstance(edge_list[0][2], int):  # type: ignore[index]
             ts = torch.tensor(edge_array[:, 2].astype(np.int_), device=device)
         else:
             ts = torch.tensor(edge_array[:, 2].astype(np.double), device=device)
 
-        index_map = IndexMap(np.unique(edge_array[:, :2]))
-        edge_index = index_map.to_idxs(edge_array[:, :2].T, device=device)
+        if mapping is None:
+            mapping = infer_mapping(edge_array[:, :2])
 
-        if not num_nodes:
-            num_nodes = index_map.num_ids()
+        num_nodes = mapping.num_ids()
+
+        edge_index = EdgeIndex(
+            mapping.to_idxs(edge_array[:, :2].T, device=device),
+            sparse_size=(num_nodes, num_nodes),
+            is_undirected=is_undirected,
+        )
 
         return TemporalGraph(
             data=Data(
@@ -124,7 +146,7 @@ class TemporalGraph(Graph):
                 time=ts,
                 num_nodes=num_nodes,
             ),
-            mapping=index_map,
+            mapping=mapping,
         )
 
     @property

--- a/tests/core/test_temporal_graph.py
+++ b/tests/core/test_temporal_graph.py
@@ -5,6 +5,8 @@ import torch
 from torch import equal
 from torch_geometric.data import Data
 
+from pathpyG.core.graph import Graph
+from pathpyG.core.index_map import IndexMap
 from pathpyG.core.temporal_graph import TemporalGraph
 from pathpyG.utils import to_numpy
 
@@ -37,6 +39,39 @@ def test_from_edge_list():
     tedges = [("a", "b", 1.0), ("b", "c", 5.0), ("c", "d", 9.0), ("c", "e", 9.0)]
     tgraph = TemporalGraph.from_edge_list(tedges)
     assert tgraph.data.time.dtype == torch.float64
+
+
+def test_from_edge_list_mapping():
+    """A mapping can name nodes that occur in no edge, which become isolated nodes."""
+    tedges = [("a", "b", 1), ("b", "c", 5)]
+    tgraph = TemporalGraph.from_edge_list(tedges, mapping=IndexMap(["a", "b", "c", "d"]))
+    assert tgraph.n == 4
+    assert tgraph.mapping.num_ids() == 4
+    assert sorted(tgraph.nodes) == ["a", "b", "c", "d"]
+
+
+def test_from_edge_list_undirected():
+    tedges = [("a", "b", 1), ("b", "a", 5)]
+    tgraph = TemporalGraph.from_edge_list(tedges, is_undirected=True)
+    assert tgraph.is_undirected()
+    assert not tgraph.is_directed()
+
+
+def test_from_edge_list_numeric_ids_match_graph():
+    """Numeric node IDs must be indexed the same way as in the base class."""
+    tgraph = TemporalGraph.from_edge_list([("1", "2", 1), ("10", "2", 5)])
+    graph = Graph.from_edge_list([("1", "2"), ("10", "2")])
+    assert [tgraph.mapping.to_idx(i) for i in ["1", "2", "10"]] == [0, 1, 2]
+    assert [tgraph.mapping.to_idx(i) for i in ["1", "2", "10"]] == [graph.mapping.to_idx(i) for i in ["1", "2", "10"]]
+
+
+def test_from_edge_list_signature_matches_base_class():
+    """The subclass must be substitutable for the base class (Liskov)."""
+    import inspect
+
+    base = list(inspect.signature(Graph.from_edge_list).parameters)
+    temporal = list(inspect.signature(TemporalGraph.from_edge_list).parameters)
+    assert temporal == base
 
 
 def test_N(long_temporal_graph):


### PR DESCRIPTION
`Graph.from_edge_index()` change - passing a mapping with more IDs than appear in the edge index would infer num_nodes from the maximum node index, so nodes named in the mapping but absent from every edge disappeared. Now `num_nodes` falls back to `mapping.num_ids()` before falling back to infer from the edge index.

`TemporalGraph.from_edge_list` now matches the base-class signature. A mapping is sufficient to express
  isolated nodes, so `num_nodes` was redundant and is taken out (it had been removed from the base class in a previous [PR](https://github.com/pathpy/pathpyG/issues/263#issuecomment-3350724295)).
  
Node ID determination is shared between the two classes, through a common `infer_mapping()`. Previously `Graph` would have sorted all-numeric string IDs numerically while `TemporalGraph` would have sorted them lexicographically.
 
Slicing an `EdgeIndex` to reorder edges by timestamp discarded its metadata. Now fixed.
 
 