### PR TITLE
Fix higher-order ID detection by checking IndexMap tuple IDs

### DIFF
--- a/src/pathpyG/core/graph.py
+++ b/src/pathpyG/core/graph.py
@@ -337,7 +337,7 @@ class Graph:
             list: list of all nodes using IDs or indices (if no mapping is used)
         """
         node_list = self.mapping.to_ids(np.arange(self.n)).tolist()
-        if self.order > 1:
+        if self.mapping.has_tuple_ids:
             return list(map(tuple, node_list))
         return node_list
 
@@ -354,7 +354,7 @@ class Graph:
             list: list object yielding all edges using IDs or indices (if no mapping is used)
         """
         edge_list = self.mapping.to_ids(self.data.edge_index.t()).tolist()
-        if self.order > 1:
+        if self.mapping.has_tuple_ids:
             return [tuple(map(tuple, x)) for x in edge_list]
         return list(map(tuple, edge_list))
 
@@ -406,7 +406,7 @@ class Graph:
         """
         node_list = self.mapping.to_ids(self.get_successors(self.mapping.to_idx(node))).tolist()  # type: ignore
 
-        if self.order > 1:
+        if self.mapping.has_tuple_ids:
             return list(map(tuple, node_list))
         return node_list
 
@@ -426,7 +426,7 @@ class Graph:
         """
         node_list = self.mapping.to_ids(self.get_predecessors(self.mapping.to_idx(node))).tolist()  # type: ignore
 
-        if self.order > 1:
+        if self.mapping.has_tuple_ids:
             return list(map(tuple, node_list))
         return node_list
 

--- a/src/pathpyG/core/index_map.py
+++ b/src/pathpyG/core/index_map.py
@@ -124,6 +124,26 @@ class IndexMap:
         """
         return self.node_ids is not None
 
+    @property
+    def has_tuple_ids(self) -> bool:
+        """Return whether IDs are tuples of first-order IDs, as in higher-order graphs.
+
+        Returns:
+            Whether IDs are tuples.
+
+        Examples:
+            Check if mapping has tuple IDs:
+
+            >>> index_map = IndexMap(["A", "B", "C"])
+            >>> print(index_map.has_tuple_ids)
+            False
+
+            >>> index_map = IndexMap([("A", "B"), ("B", "C")])
+            >>> print(index_map.has_tuple_ids)
+            True
+        """
+        return len(self.id_shape) > 1
+
     def num_ids(self) -> int:
         """Return number of IDs. If mapping is not defined, return 0.
 

--- a/src/pathpyG/visualisations/network_plot.py
+++ b/src/pathpyG/visualisations/network_plot.py
@@ -127,7 +127,7 @@ class NetworkPlot(PathPyPlot):
         # initialize values
         nodes: pd.DataFrame = pd.DataFrame(index=self.network.nodes)
         # if higher-order network, convert node tuples to string representation
-        if self.network.order > 1:
+        if self.network.mapping.has_tuple_ids:
             nodes.index = nodes.index.map(lambda x: self.config["separator"].join(map(str, x)))
         for attribute in self.attributes:
             # set default value for each attribute based on the pathpyG.toml config
@@ -172,7 +172,7 @@ class NetworkPlot(PathPyPlot):
         # initialize values
         edges: pd.DataFrame = pd.DataFrame(index=pd.MultiIndex.from_tuples(self.network.edges, names=["source", "target"]))
         # if higher-order network, convert node tuples to string representation
-        if self.network.order > 1:
+        if self.network.mapping.has_tuple_ids:
             edges.index = edges.index.map(lambda x: (self.config["separator"].join(map(str, x[0])), self.config["separator"].join(map(str, x[1]))))
         for attribute in self.attributes:
             # set default value for each attribute based on the pathpyG.toml config
@@ -365,7 +365,7 @@ class NetworkPlot(PathPyPlot):
 
         # update x,y position of the nodes
         layout_df = pd.DataFrame.from_dict(layout, orient="index", columns=["x", "y"])
-        if self.network.order > 1 and not isinstance(layout_df.index[0], str):
+        if self.network.mapping.has_tuple_ids and not isinstance(layout_df.index[0], str):
             layout_df.index = layout_df.index.map(lambda x: self.config["separator"].join(map(str, x)))
         # scale x and y to [0,1]
         layout_df["x"] = (layout_df["x"] - layout_df["x"].min()) / (layout_df["x"].max() - layout_df["x"].min())

--- a/src/pathpyG/visualisations/temporal_network_plot.py
+++ b/src/pathpyG/visualisations/temporal_network_plot.py
@@ -217,7 +217,7 @@ class TemporalNetworkPlot(NetworkPlot):
 
             # update x,y position of the nodes
             new_layout_df = pd.DataFrame.from_dict(pos, orient="index", columns=["x", "y"])
-            if self.network.order > 1 and not isinstance(new_layout_df.index[0], str):
+            if self.network.mapping.has_tuple_ids and not isinstance(new_layout_df.index[0], str):
                 new_layout_df.index = new_layout_df.index.map(lambda x: self.config["separator"].join(map(str, x)))
             # scale x and y to [0,1]
             new_layout_df["x"] = (new_layout_df["x"] - new_layout_df["x"].min()) / (

--- a/tests/visualisations/test_network_plot.py
+++ b/tests/visualisations/test_network_plot.py
@@ -200,7 +200,7 @@ class TestNetworkPlot:
         plot = NetworkPlot(ho_g, node_color="#123456")
         nodes = plot.data["nodes"]
         # Index should be stringified tuples
-        assert all(isinstance(idx, str) for idx in nodes.index)
+        assert list(nodes.index) == ["a->b", "a->d", "b->c", "c->a"]
 
     def test_invalid_image_path_raises(self):
         with pytest.raises(AttributeError):


### PR DESCRIPTION
Closes #323 

Node/edge iteration and plotting decided whether IDs were tuples by checking `graph.order > 1`. This PR bases the decision on the actual ID structure instead of graph order.

Graph order and ID structure may not always coincide - in an upcoming `EventGraph`, the order is 2, but it provides its own mapping IDs constructed from the underlying `TemporalGraph`. The same will probably be true for an upcoming `HigherOrderGraph`.

  
