### PR TITLE
Workflow for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          python-version: "3.13"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing always
+
+      - name: Create release tag
+        # Adding a `--prerelease` flag in `gh release create` makes the release not
+        # show up as the latest stable release.
+        run: |
+          version="$(uv version --short)"
+          if uv run --no-project --with packaging python -c \
+              "import sys; from packaging.version import Version; sys.exit(0 if Version('${version}').is_prerelease else 1)"; then
+            prerelease="--prerelease"
+          else
+            prerelease=""
+          fi
+          gh release create "v${version}" --title "v${version}" --generate-notes ${prerelease}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Environment :: GPU :: NVIDIA CUDA :: 11.8",
 ]
 requires-python = ">=3.10" # We are using `match` statements
-version = "0.2.0"
+version = "v1.0.0rc1"
 dependencies = [
     'singledispatchmethod', # Adds decorator that allows to use different methods for different types of arguments (similar to method overloading in Java)
     'zstandard', # Compression library


### PR DESCRIPTION
I've created a [trusted publisher](https://docs.pypi.org/trusted-publishers/) on my pypi account (any other user can create it too in the future), and added a release workflow on merge to `main`. The package on pypi will be called `pathpyG`.

I've bumped the version to `v1.0.0.rc1` so a regular `pip install pathpyG` won't pick it up (yet) - it can be forced it `pip install --pre pathpyG`. Once we move to regular version numbers, it will work.

This setup has worked for me in other projects, but we'll find out more once we do a test pre-release.